### PR TITLE
Implement Fixture-level test dependencies

### DIFF
--- a/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
@@ -18,9 +18,6 @@ namespace NUnit.Framework
         /// <param name="dependencyType">The type of fixture that must finish before this fixture starts.</param>
         public DependsOnAttribute(Type dependencyType)
         {
-            if (dependencyType is null)
-                throw new ArgumentNullException(nameof(dependencyType));
-
             DependencyType = dependencyType;
         }
 

--- a/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
@@ -15,16 +15,16 @@ namespace NUnit.Framework
         /// <summary>
         /// Initializes a new instance of the <see cref="DependsOnAttribute"/> class.
         /// </summary>
-        /// <param name="dependencyType">The type of fixture that must finish before this fixture starts.</param>
-        public DependsOnAttribute(Type dependencyType)
+        /// <param name="dependantFixture">The test fixture that must finish before this fixture starts.</param>
+        public DependsOnAttribute(Type dependantFixture)
         {
-            DependencyType = dependencyType;
+            DependantFixture = dependantFixture;
         }
 
         /// <summary>
-        /// Gets the type of fixture that must finish before this fixture starts.
+        /// Gets the test fixture that must finish before this fixture starts.
         /// </summary>
-        public Type DependencyType { get; }
+        public Type DependantFixture { get; }
 
         /// <summary>
         /// Applies dependency metadata to a test.
@@ -32,7 +32,7 @@ namespace NUnit.Framework
         /// <param name="test">The test.</param>
         public void ApplyToTest(Test test)
         {
-            test.Properties.Set(PropertyNames.DependsOn, DependencyType);
+            test.Properties.Set(PropertyNames.DependsOn, DependantFixture);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
@@ -13,6 +13,11 @@ namespace NUnit.Framework
     public sealed class DependsOnAttribute : NUnitAttribute, IApplyToTest, IApplyToTestSuite
     {
         /// <summary>
+        /// Gets or sets a value indicating whether the dependent fixture must succeed for this fixture to run.
+        /// </summary>
+        public bool RequiresSuccess { get; set; } = true;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DependsOnAttribute"/> class.
         /// </summary>
         /// <param name="dependantFixture">The test fixture that must finish before this fixture starts.</param>
@@ -33,6 +38,7 @@ namespace NUnit.Framework
         public void ApplyToTest(Test test)
         {
             test.Properties.Set(PropertyNames.DependsOn, DependantFixture);
+            test.Properties.Set(PropertyNames.DependsOnRequiresSuccess, RequiresSuccess);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
@@ -13,11 +13,6 @@ namespace NUnit.Framework
     public sealed class DependsOnAttribute : NUnitAttribute, IApplyToTest, IApplyToTestSuite
     {
         /// <summary>
-        /// Gets or sets a value indicating whether the dependent fixture must succeed for this fixture to run.
-        /// </summary>
-        public bool RequiresSuccess { get; set; } = true;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="DependsOnAttribute"/> class.
         /// </summary>
         /// <param name="dependantFixture">The test fixture that must finish before this fixture starts.</param>
@@ -25,6 +20,11 @@ namespace NUnit.Framework
         {
             DependantFixture = dependantFixture;
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the dependent fixture is allowed to fail without affecting this fixture.
+        /// </summary>
+        public bool AllowFailure { get; set; } = false;
 
         /// <summary>
         /// Gets the test fixture that must finish before this fixture starts.
@@ -38,7 +38,7 @@ namespace NUnit.Framework
         public void ApplyToTest(Test test)
         {
             test.Properties.Set(PropertyNames.DependsOn, DependantFixture);
-            test.Properties.Set(PropertyNames.DependsOnRequiresSuccess, RequiresSuccess);
+            test.Properties.Set(PropertyNames.DependsOnAllowFailure, AllowFailure);
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
@@ -10,7 +10,7 @@ namespace NUnit.Framework
     /// Specifies that a test fixture must run after another fixture.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    public sealed class DependsOnAttribute : NUnitAttribute, IApplyToTest, IApplyToTestSuite
+    public sealed class DependsOnAttribute : NUnitAttribute, IApplyToTest
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DependsOnAttribute"/> class.
@@ -39,15 +39,6 @@ namespace NUnit.Framework
         {
             test.Properties.Set(PropertyNames.DependsOnFixture, DependantFixture);
             test.Properties.Set(PropertyNames.DependsOnAllowFailure, AllowFailure);
-        }
-
-        /// <summary>
-        /// Applies dependency metadata to the fixture suite.
-        /// </summary>
-        /// <param name="testSuite">The fixture suite.</param>
-        public void ApplyToTestSuite(TestSuite testSuite)
-        {
-            ApplyToTest(testSuite);
         }
     }
 }

--- a/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework
         /// <param name="test">The test.</param>
         public void ApplyToTest(Test test)
         {
-            test.Properties.Set(PropertyNames.DependsOn, DependantFixture);
+            test.Properties.Set(PropertyNames.DependsOnType, DependantFixture);
             test.Properties.Set(PropertyNames.DependsOnAllowFailure, AllowFailure);
         }
 

--- a/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace NUnit.Framework
+{
+    /// <summary>
+    /// Specifies that a test fixture must run after another fixture.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class DependsOnAttribute : NUnitAttribute, IApplyToTest, IApplyToTestSuite
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DependsOnAttribute"/> class.
+        /// </summary>
+        /// <param name="dependencyType">The type of fixture that must finish before this fixture starts.</param>
+        public DependsOnAttribute(Type dependencyType)
+        {
+            if (dependencyType is null)
+                throw new ArgumentNullException(nameof(dependencyType));
+
+            DependencyType = dependencyType;
+        }
+
+        /// <summary>
+        /// Gets the type of fixture that must finish before this fixture starts.
+        /// </summary>
+        public Type DependencyType { get; }
+
+        /// <summary>
+        /// Applies dependency metadata to a test.
+        /// </summary>
+        /// <param name="test">The test.</param>
+        public void ApplyToTest(Test test)
+        {
+            test.Properties.Set(PropertyNames.DependsOn, DependencyType);
+        }
+
+        /// <summary>
+        /// Applies dependency metadata to the fixture suite.
+        /// </summary>
+        /// <param name="testSuite">The fixture suite.</param>
+        public void ApplyToTestSuite(TestSuite testSuite)
+        {
+            ApplyToTest(testSuite);
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/DependsOnAttribute.cs
@@ -37,7 +37,7 @@ namespace NUnit.Framework
         /// <param name="test">The test.</param>
         public void ApplyToTest(Test test)
         {
-            test.Properties.Set(PropertyNames.DependsOnType, DependantFixture);
+            test.Properties.Set(PropertyNames.DependsOnFixture, DependantFixture);
             test.Properties.Set(PropertyNames.DependsOnAllowFailure, AllowFailure);
         }
 

--- a/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
@@ -10,7 +10,7 @@ namespace NUnit.Framework
     /// Defines the order that the test will run in
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-    public class OrderAttribute : NUnitAttribute, IApplyToTest, IApplyToTestSuite
+    public class OrderAttribute : NUnitAttribute, IApplyToTest
     {
         /// <summary>
         /// The order that the test will run in
@@ -34,16 +34,6 @@ namespace NUnit.Framework
         {
             if (!test.Properties.ContainsKey(PropertyNames.Order))
                 test.Properties.Set(PropertyNames.Order, Order);
-        }
-
-        /// <summary>
-        /// Modifies a test suite as defined for the specific attribute.
-        /// </summary>
-        /// <param name="testSuite">The test suite to modify</param>
-        public void ApplyToTestSuite(TestSuite testSuite)
-        {
-            if (!testSuite.Properties.ContainsKey(PropertyNames.Order))
-                testSuite.Properties.Set(PropertyNames.Order, Order);
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -288,7 +288,7 @@ namespace NUnit.Framework.Internal.Execution
                     TestStatus? dependencyStatus = GetDependencyStatus(child);
                     if (dependencyStatus.HasValue && dependencyStatus is not (TestStatus.Passed or TestStatus.Warning))
                     {
-                        Type? dependsOnType = child.Test.Properties.Get(PropertyNames.DependsOn) as Type;
+                        Type? dependsOnType = child.Test.Properties.Get(PropertyNames.DependsOnType) as Type;
                         string message = $"Dependency on {dependsOnType!.FullName} did not pass";
                         SetChildWorkItemSkippedResult(child.Result, ResultState.Skipped, message, null);
 
@@ -368,7 +368,7 @@ namespace NUnit.Framework.Internal.Execution
             if (child.Test.Properties.TryGet(PropertyNames.DependsOnAllowFailure, false))
                 return null;
 
-            Type? dependsOnType = child.Test.Properties.Get(PropertyNames.DependsOn) as Type;
+            Type? dependsOnType = child.Test.Properties.Get(PropertyNames.DependsOnType) as Type;
             if (dependsOnType is null)
                 return null;
 

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -288,17 +288,11 @@ namespace NUnit.Framework.Internal.Execution
                     TestStatus? dependencyStatus = GetDependencyStatus(child);
                     if (dependencyStatus.HasValue && dependencyStatus is not (TestStatus.Passed or TestStatus.Warning))
                     {
-                        var dependsOnType = child.Test.TypeInfo!.Type;
-                        string message = $"Dependency on {dependsOnType.FullName} did not pass";
-                        SetChildWorkItemSkippedResult(child.Result, ResultState.Skipped, message, null);
+                        var dependant = child.Test.DependantTest!;
+                        var message = $"Dependency on {dependant.Name} did not pass";
 
-                        lock (_childCompletionLock)
-                        {
-                            _suiteResult.AddResult(child.Result);
-                            _childTestCountdown.Signal();
-                            if (_childTestCountdown.CurrentCount == 0)
-                                OnAllChildItemsCompleted();
-                        }
+                        SetChildWorkItemSkippedResult(child.Result, ResultState.Skipped, message, null);
+                        OnChildItemCompleted(child, EventArgs.Empty);
 
                         childCount--;
                         continue;

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -283,6 +283,29 @@ namespace NUnit.Framework.Internal.Execution
                 if (CheckForCancellation())
                     break;
 
+                if (child.Test.RunState is RunState.Runnable or RunState.Explicit)
+                {
+                    TestStatus? dependencyStatus = GetDependencyStatus(child);
+                    if (dependencyStatus.HasValue && dependencyStatus is not (TestStatus.Passed or TestStatus.Warning))
+                    {
+                        Type? dependsOnType = child.Test.Properties.Get(PropertyNames.DependsOn) as Type;
+                        string dependencyName = dependsOnType?.Name ?? "Unknown";
+                        string message = $"Dependency on {dependencyName} did not pass";
+                        SetChildWorkItemSkippedResult(child.Result, ResultState.Skipped, message, null);
+
+                        lock (_childCompletionLock)
+                        {
+                            _suiteResult.AddResult(child.Result);
+                            _childTestCountdown!.Signal();
+                            if (_childTestCountdown.CurrentCount == 0)
+                                OnAllChildItemsCompleted();
+                        }
+
+                        childCount--;
+                        continue;
+                    }
+                }
+
                 child.Completed += new EventHandler(OnChildItemCompleted);
                 child.InitializeContext(new TestExecutionContext(Context));
 
@@ -334,6 +357,30 @@ namespace NUnit.Framework.Internal.Execution
             result.StartTime = Context.StartTime;
             result.EndTime = DateTime.UtcNow;
             result.Duration = Context.Duration;
+        }
+
+        /// <summary>
+        /// Gets the status of a child's dependency, if any.
+        /// Returns null if the child has no dependency or the dependency hasn't been run yet.
+        /// </summary>
+        private TestStatus? GetDependencyStatus(WorkItem child)
+        {
+            var dependsOnType = child.Test.Properties.Get(PropertyNames.DependsOn) as Type;
+            if (dependsOnType is null)
+                return null;
+
+            // Find the dependency fixture in our children
+            foreach (var potentialDependency in Children)
+            {
+                if (potentialDependency.Test is Test fixture && fixture.TypeInfo?.Type == dependsOnType)
+                {
+                    // Return the status of the dependency if it has a result
+                    if (potentialDependency.Result.ResultState is ResultState resultState)
+                        return resultState.Status;
+                }
+            }
+
+            return null;
         }
 
         private void PerformOneTimeTearDown()

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -288,14 +288,14 @@ namespace NUnit.Framework.Internal.Execution
                     TestStatus? dependencyStatus = GetDependencyStatus(child);
                     if (dependencyStatus.HasValue && dependencyStatus is not (TestStatus.Passed or TestStatus.Warning))
                     {
-                        Type? dependsOnType = child.Test.Properties.Get(PropertyNames.DependsOnType) as Type;
-                        string message = $"Dependency on {dependsOnType!.FullName} did not pass";
+                        var dependsOnType = (Type)child.Test.Properties.Get(PropertyNames.DependsOnType)!;
+                        string message = $"Dependency on {dependsOnType.FullName} did not pass";
                         SetChildWorkItemSkippedResult(child.Result, ResultState.Skipped, message, null);
 
                         lock (_childCompletionLock)
                         {
                             _suiteResult.AddResult(child.Result);
-                            _childTestCountdown!.Signal();
+                            _childTestCountdown.Signal();
                             if (_childTestCountdown.CurrentCount == 0)
                                 OnAllChildItemsCompleted();
                         }

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -362,22 +362,21 @@ namespace NUnit.Framework.Internal.Execution
             if (child.Test.Properties.TryGet(PropertyNames.DependsOnAllowFailure, false))
                 return null;
 
-            Test? dependantTest = child.Test.DependantTest;
+            ITest? dependantTest = child.Test.DependantTest;
             if (dependantTest is null)
                 return null;
 
             // Find the dependency fixture in our children
-            foreach (WorkItem potentialDependency in Children)
+            WorkItem? dependency = Children.Find(c => c.Test == dependantTest);
+            if (dependency is not null)
             {
-                if (potentialDependency.Test is Test test && test == dependantTest)
-                {
-                    // Return the status of the dependency if it has completed
-                    // Otherwise, return null to indicate that the dependency hasn't been run yet or hasn't finished running
-                    if (potentialDependency.Result.ResultState is ResultState resultState)
-                        return resultState.Status;
-                }
+                // Return the status of the dependency
+                return dependency.Result.ResultState.Status;
             }
 
+            // This would indicate an error in the framework,
+            // when the test is runnable,
+            // but the dependency is not found in the same suite.
             return null;
         }
 

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -289,8 +289,7 @@ namespace NUnit.Framework.Internal.Execution
                     if (dependencyStatus.HasValue && dependencyStatus is not (TestStatus.Passed or TestStatus.Warning))
                     {
                         Type? dependsOnType = child.Test.Properties.Get(PropertyNames.DependsOn) as Type;
-                        string dependencyName = dependsOnType?.Name ?? "Unknown";
-                        string message = $"Dependency on {dependencyName} did not pass";
+                        string message = $"Dependency on {dependsOnType!.FullName} did not pass";
                         SetChildWorkItemSkippedResult(child.Result, ResultState.Skipped, message, null);
 
                         lock (_childCompletionLock)
@@ -378,7 +377,8 @@ namespace NUnit.Framework.Internal.Execution
             {
                 if (potentialDependency.Test is Test fixture && fixture.TypeInfo?.Type == dependsOnType)
                 {
-                    // Return the status of the dependency if it has a result
+                    // Return the status of the dependency if it has completed
+                    // Otherwise, return null to indicate that the dependency hasn't been run yet or hasn't finished running
                     if (potentialDependency.Result.ResultState is ResultState resultState)
                         return resultState.Status;
                 }

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -289,8 +289,7 @@ namespace NUnit.Framework.Internal.Execution
                     if (dependencyStatus.HasValue && dependencyStatus is not (TestStatus.Passed or TestStatus.Warning))
                     {
                         Type? dependsOnType = child.Test.Properties.Get(PropertyNames.DependsOn) as Type;
-                        string dependencyName = dependsOnType?.Name ?? "Unknown";
-                        string message = $"Dependency on {dependencyName} did not pass";
+                        string message = $"Dependency on {dependsOnType!.FullName} did not pass";
                         SetChildWorkItemSkippedResult(child.Result, ResultState.Skipped, message, null);
 
                         lock (_childCompletionLock)

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -288,7 +288,7 @@ namespace NUnit.Framework.Internal.Execution
                     TestStatus? dependencyStatus = GetDependencyStatus(child);
                     if (dependencyStatus.HasValue && dependencyStatus is not (TestStatus.Passed or TestStatus.Warning))
                     {
-                        var dependsOnType = (Type)child.Test.Properties.Get(PropertyNames.DependsOnType)!;
+                        var dependsOnType = child.Test.TypeInfo!.Type;
                         string message = $"Dependency on {dependsOnType.FullName} did not pass";
                         SetChildWorkItemSkippedResult(child.Result, ResultState.Skipped, message, null);
 
@@ -368,14 +368,14 @@ namespace NUnit.Framework.Internal.Execution
             if (child.Test.Properties.TryGet(PropertyNames.DependsOnAllowFailure, false))
                 return null;
 
-            Type? dependsOnType = child.Test.Properties.Get(PropertyNames.DependsOnType) as Type;
-            if (dependsOnType is null)
+            Test? dependantTest = child.Test.DependantTest;
+            if (dependantTest is null)
                 return null;
 
             // Find the dependency fixture in our children
             foreach (WorkItem potentialDependency in Children)
             {
-                if (potentialDependency.Test is Test fixture && fixture.TypeInfo?.Type == dependsOnType)
+                if (potentialDependency.Test is Test test && test == dependantTest)
                 {
                     // Return the status of the dependency if it has completed
                     // Otherwise, return null to indicate that the dependency hasn't been run yet or hasn't finished running

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -361,16 +361,20 @@ namespace NUnit.Framework.Internal.Execution
 
         /// <summary>
         /// Gets the status of a child's dependency, if any.
-        /// Returns null if the child has no dependency or the dependency hasn't been run yet.
+        /// Returns null if the child has no dependency, does not require a passing dependency,
+        /// or the dependency hasn't been run yet.
         /// </summary>
         private TestStatus? GetDependencyStatus(WorkItem child)
         {
-            var dependsOnType = child.Test.Properties.Get(PropertyNames.DependsOn) as Type;
+            if (!child.Test.Properties.TryGet(PropertyNames.DependsOnRequiresSuccess, true))
+                return null;
+
+            Type? dependsOnType = child.Test.Properties.Get(PropertyNames.DependsOn) as Type;
             if (dependsOnType is null)
                 return null;
 
             // Find the dependency fixture in our children
-            foreach (var potentialDependency in Children)
+            foreach (WorkItem potentialDependency in Children)
             {
                 if (potentialDependency.Test is Test fixture && fixture.TypeInfo?.Type == dependsOnType)
                 {

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -366,7 +366,7 @@ namespace NUnit.Framework.Internal.Execution
         /// </summary>
         private TestStatus? GetDependencyStatus(WorkItem child)
         {
-            if (!child.Test.Properties.TryGet(PropertyNames.DependsOnRequiresSuccess, true))
+            if (child.Test.Properties.TryGet(PropertyNames.DependsOnAllowFailure, false))
                 return null;
 
             Type? dependsOnType = child.Test.Properties.Get(PropertyNames.DependsOn) as Type;

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using NUnit.Framework.Interfaces;
@@ -54,6 +55,8 @@ namespace NUnit.Framework.Internal.Execution
 
             if (recursive)
             {
+                PrepareFixtureDependencies(suite);
+
                 int countOrderedItems = 0;
 
                 foreach (var childTest in suite.Tests)
@@ -80,8 +83,81 @@ namespace NUnit.Framework.Internal.Execution
 
                 if (countOrderedItems > 0)
                     work!.Children.Sort(0, countOrderedItems, new WorkItemOrderComparer());
+
+                if (work is not null)
+                    ReorderChildrenByDependency(work.Children);
             }
             return work;
+        }
+
+        private static void PrepareFixtureDependencies(TestSuite suite)
+        {
+            var fixturesByType = new Dictionary<Type, Test>();
+            var dependencyByFixture = new Dictionary<Test, Type>();
+
+            foreach (var child in suite.Tests)
+            {
+                if (child is not Test fixture || fixture.TypeInfo?.Type is null)
+                    continue;
+
+                fixturesByType[fixture.TypeInfo.Type] = fixture;
+
+                if (fixture.Properties.Get(PropertyNames.DependsOn) is Type dependencyType)
+                    dependencyByFixture[fixture] = dependencyType;
+            }
+
+            foreach (var dependency in dependencyByFixture)
+            {
+                if (!fixturesByType.TryGetValue(dependency.Value, out var dependencyFixture))
+                    continue;
+
+                dependency.Key.Properties.Set(PropertyNames.ParallelScope, ParallelScope.None);
+                dependencyFixture.Properties.Set(PropertyNames.ParallelScope, ParallelScope.None);
+            }
+        }
+
+        private static void ReorderChildrenByDependency(List<WorkItem> children)
+        {
+            if (children.Count < 2)
+                return;
+
+            bool moved;
+            int remainingPasses = children.Count * children.Count;
+
+            do
+            {
+                moved = false;
+
+                var indexByType = new Dictionary<Type, int>();
+                for (int i = 0; i < children.Count; i++)
+                {
+                    if (children[i].Test is Test fixture && fixture.TypeInfo?.Type is Type fixtureType)
+                        indexByType[fixtureType] = i;
+                }
+
+                for (int i = 0; i < children.Count; i++)
+                {
+                    if (children[i].Test is not Test fixture || fixture.Properties.Get(PropertyNames.DependsOn) is not Type dependencyType)
+                        continue;
+
+                    if (!indexByType.TryGetValue(dependencyType, out int dependencyIndex) || dependencyIndex < i)
+                        continue;
+
+                    if (dependencyIndex == i)
+                        continue;
+
+                    var dependentChild = children[i];
+                    children.RemoveAt(i);
+
+                    if (dependencyIndex > i)
+                        dependencyIndex--;
+
+                    children.Insert(dependencyIndex + 1, dependentChild);
+                    moved = true;
+                    break;
+                }
+            }
+            while (moved && remainingPasses-- > 0);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -121,7 +121,7 @@ namespace NUnit.Framework.Internal.Execution
 
                 fixturesByType[fixture.TypeInfo.Type] = fixture;
 
-                if (fixture.Properties.Get(PropertyNames.DependsOn) is Type dependencyType)
+                if (fixture.Properties.Get(PropertyNames.DependsOnType) is Type dependencyType)
                     dependencyByFixture[fixture] = dependencyType;
             }
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -125,18 +125,24 @@ namespace NUnit.Framework.Internal.Execution
                     dependencyByFixture[fixture] = dependencyType;
             }
 
+            foreach (var pair in dependencyByFixture)
+            {
+                if (fixturesByType.TryGetValue(pair.Value, out Test? dependencyFixture))
+                    dependencyGraph[pair.Key] = dependencyFixture;
+            }
+
             MarkInvalidDependenciesAsInvalid(fixturesByType, dependencyByFixture);
-            MarkDependencyFeatureConflictsAsInvalid(fixturesByType, dependencyByFixture);
+            MarkDependencyFeatureConflictsAsInvalid(dependencyGraph);
 
             foreach (var pair in dependencyByFixture)
             {
                 var fixture = pair.Key;
 
-                if (fixture.RunState == RunState.Runnable
-                    && fixturesByType.TryGetValue(pair.Value, out Test? dependencyFixture)
-                    && dependencyFixture.RunState == RunState.Runnable)
+                if (fixture.RunState != RunState.Runnable
+                    || !fixturesByType.TryGetValue(pair.Value, out Test? dependencyFixture)
+                    || dependencyFixture.RunState != RunState.Runnable)
                 {
-                    dependencyGraph[fixture] = dependencyFixture;
+                    dependencyGraph[fixture] = null;
                 }
             }
 
@@ -215,23 +221,28 @@ namespace NUnit.Framework.Internal.Execution
             }
         }
 
-        private static void MarkDependencyFeatureConflictsAsInvalid(Dictionary<Type, Test> fixturesByType, Dictionary<Test, Type> dependencyByFixture)
+        private static void MarkDependencyFeatureConflictsAsInvalid(Dictionary<ITest, ITest?> dependencyGraph)
         {
             const string orderReason = "Fixture may not participate in both DependsOn and Order chains.";
             const string parallelReason = "Fixture dependency chains may not include fixtures configured for parallel execution.";
 
-            var dependencyParticipants = new HashSet<Test>(dependencyByFixture.Keys);
-
-            foreach (var dependency in dependencyByFixture.Values)
+            foreach (var pair in dependencyGraph)
             {
-                if (fixturesByType.TryGetValue(dependency, out Test? dependencyFixture))
-                    dependencyParticipants.Add(dependencyFixture);
+                if (pair.Key is not Test fixture || pair.Value is not Test dependencyFixture)
+                    continue;
+
+                MarkDependencyFeatureConflictsAsInvalid(fixture);
+                MarkDependencyFeatureConflictsAsInvalid(dependencyFixture);
             }
 
-            foreach (var fixture in dependencyParticipants)
+            static void MarkDependencyFeatureConflictsAsInvalid(Test? fixture)
             {
+                if (fixture is null)
+                    return;
+
                 if (fixture.Properties.ContainsKey(PropertyNames.Order))
                     fixture.MakeInvalid(orderReason);
+
                 if (IsConfiguredParallelWithOtherFixtures(fixture))
                     fixture.MakeInvalid(parallelReason);
             }

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -117,8 +117,7 @@ namespace NUnit.Framework.Internal.Execution
 
             var invalidCircularDependencies = new HashSet<Test>();
             var visited = new HashSet<Test>();
-            var visiting = new HashSet<Test>();
-            var stack = new List<Test>();
+            var visiting = new List<Test>();
 
             foreach (var fixture in dependencyByFixture.Keys)
                 Visit(fixture);
@@ -129,7 +128,6 @@ namespace NUnit.Framework.Internal.Execution
                     return;
 
                 visiting.Add(fixture);
-                stack.Add(fixture);
 
                 if (dependencyByFixture.TryGetValue(fixture, out Type? dependencyType))
                 {
@@ -141,9 +139,9 @@ namespace NUnit.Framework.Internal.Execution
                     {
                         if (visiting.Contains(dependencyFixture))
                         {
-                            int cycleStartIndex = stack.IndexOf(dependencyFixture);
+                            int cycleStartIndex = visiting.IndexOf(dependencyFixture);
                             if (cycleStartIndex >= 0)
-                                MarkCycle(stack, cycleStartIndex);
+                                MarkCycle(visiting, cycleStartIndex);
                         }
                         else
                         {
@@ -160,8 +158,7 @@ namespace NUnit.Framework.Internal.Execution
                     }
                 }
 
-                stack.RemoveAt(stack.Count - 1);
-                visiting.Remove(fixture);
+                visiting.RemoveAt(visiting.Count - 1);
             }
 
             static bool IsSelfReferentialBaseDependency(Test fixture, Type dependencyType)

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -106,6 +106,8 @@ namespace NUnit.Framework.Internal.Execution
                     dependencyByFixture[fixture] = dependencyType;
             }
 
+            MarkCircularDependenciesAsInvalid(fixturesByType, dependencyByFixture);
+
             foreach (var dependency in dependencyByFixture)
             {
                 if (!fixturesByType.TryGetValue(dependency.Value, out var dependencyFixture))
@@ -113,6 +115,52 @@ namespace NUnit.Framework.Internal.Execution
 
                 dependency.Key.Properties.Set(PropertyNames.ParallelScope, ParallelScope.None);
                 dependencyFixture.Properties.Set(PropertyNames.ParallelScope, ParallelScope.None);
+            }
+        }
+
+        private static void MarkCircularDependenciesAsInvalid(Dictionary<Type, Test> fixturesByType, Dictionary<Test, Type> dependencyByFixture)
+        {
+            var visited = new HashSet<Test>();
+            var visiting = new HashSet<Test>();
+            var stack = new List<Test>();
+
+            foreach (var fixture in dependencyByFixture.Keys)
+                Visit(fixture);
+
+            void Visit(Test fixture)
+            {
+                if (visited.Contains(fixture))
+                    return;
+
+                visited.Add(fixture);
+                visiting.Add(fixture);
+                stack.Add(fixture);
+
+                if (dependencyByFixture.TryGetValue(fixture, out Type? dependencyType)
+                    && fixturesByType.TryGetValue(dependencyType, out Test? dependencyFixture))
+                {
+                    if (visiting.Contains(dependencyFixture))
+                    {
+                        int cycleStartIndex = stack.IndexOf(dependencyFixture);
+                        if (cycleStartIndex >= 0)
+                            MarkCycle(stack, cycleStartIndex);
+                    }
+                    else
+                    {
+                        Visit(dependencyFixture);
+                    }
+                }
+
+                stack.RemoveAt(stack.Count - 1);
+                visiting.Remove(fixture);
+            }
+
+            static void MarkCycle(List<Test> dependencyPath, int cycleStartIndex)
+            {
+                const string reason = "Circular DependsOn dependency detected.";
+
+                for (int i = cycleStartIndex; i < dependencyPath.Count; i++)
+                    dependencyPath[i].MakeInvalid(reason);
             }
         }
 
@@ -137,10 +185,13 @@ namespace NUnit.Framework.Internal.Execution
 
                 for (int i = 0; i < children.Count; i++)
                 {
-                    if (children[i].Test is not Test fixture || fixture.Properties.Get(PropertyNames.DependsOn) is not Type dependencyType)
+                    if (children[i].Test is not Test fixture || fixture.RunState == RunState.NotRunnable || fixture.Properties.Get(PropertyNames.DependsOn) is not Type dependencyType)
                         continue;
 
                     if (!indexByType.TryGetValue(dependencyType, out int dependencyIndex) || dependencyIndex < i)
+                        continue;
+
+                    if (children[dependencyIndex].Test is Test dependencyFixture && dependencyFixture.RunState == RunState.NotRunnable)
                         continue;
 
                     if (dependencyIndex == i)

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -107,16 +107,7 @@ namespace NUnit.Framework.Internal.Execution
             }
 
             MarkCircularDependenciesAsInvalid(fixturesByType, dependencyByFixture);
-            MarkDependencyAndOrderConflictsAsInvalid(fixturesByType, dependencyByFixture);
-
-            foreach (var dependency in dependencyByFixture)
-            {
-                if (!fixturesByType.TryGetValue(dependency.Value, out var dependencyFixture))
-                    continue;
-
-                dependency.Key.Properties.Set(PropertyNames.ParallelScope, ParallelScope.None);
-                dependencyFixture.Properties.Set(PropertyNames.ParallelScope, ParallelScope.None);
-            }
+            MarkDependencyConflictsAsInvalid(fixturesByType, dependencyByFixture);
         }
 
         private static void MarkCircularDependenciesAsInvalid(Dictionary<Type, Test> fixturesByType, Dictionary<Test, Type> dependencyByFixture)
@@ -165,9 +156,10 @@ namespace NUnit.Framework.Internal.Execution
             }
         }
 
-        private static void MarkDependencyAndOrderConflictsAsInvalid(Dictionary<Type, Test> fixturesByType, Dictionary<Test, Type> dependencyByFixture)
+        private static void MarkDependencyConflictsAsInvalid(Dictionary<Type, Test> fixturesByType, Dictionary<Test, Type> dependencyByFixture)
         {
-            const string reason = "Fixture may not participate in both DependsOn and Order chains.";
+            const string orderReason = "Fixture may not participate in both DependsOn and Order chains.";
+            const string parallelReason = "Fixture dependency chains may not include fixtures configured for parallel execution.";
 
             var dependencyParticipants = new HashSet<Test>(dependencyByFixture.Keys);
 
@@ -180,7 +172,15 @@ namespace NUnit.Framework.Internal.Execution
             foreach (var fixture in dependencyParticipants)
             {
                 if (fixture.Properties.ContainsKey(PropertyNames.Order))
-                    fixture.MakeInvalid(reason);
+                    fixture.MakeInvalid(orderReason);
+                if (IsConfiguredParallelWithOtherFixtures(fixture))
+                    fixture.MakeInvalid(parallelReason);
+            }
+
+            static bool IsConfiguredParallelWithOtherFixtures(Test fixture)
+            {
+                var scope = fixture.Properties.TryGet(PropertyNames.ParallelScope, ParallelScope.Default);
+                return scope.HasFlag(ParallelScope.Self) && !scope.HasFlag(ParallelScope.None);
             }
         }
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -56,7 +56,7 @@ namespace NUnit.Framework.Internal.Execution
             if (recursive)
             {
                 var testDependencies = PrepareTestDependencies(suite);
-                var children = testDependencies is null ? suite.Tests : TopologicalSort(testDependencies);
+                var children = testDependencies is null ? suite.Tests : TopologicalSort(suite.Tests, testDependencies);
 
                 int countOrderedItems = 0;
 
@@ -88,20 +88,20 @@ namespace NUnit.Framework.Internal.Execution
             return work;
         }
 
-        private static List<ITest> TopologicalSort(Dictionary<Test, Test?> dependencyGraph)
+        private static List<ITest> TopologicalSort(IList<ITest> tests, Dictionary<ITest, ITest> dependencyGraph)
         {
             var sorted = new List<ITest>(dependencyGraph.Count);
             var visited = new HashSet<ITest>();
 
-            foreach (var fixture in dependencyGraph.Keys)
+            foreach (var fixture in tests)
                 Visit(fixture);
 
-            void Visit(Test fixture)
+            void Visit(ITest fixture)
             {
                 if (!visited.Add(fixture))
                     return;
 
-                if (dependencyGraph.TryGetValue(fixture, out Test? dependency) && dependency is not null)
+                if (dependencyGraph.TryGetValue(fixture, out ITest? dependency))
                     Visit(dependency);
 
                 sorted.Add(fixture);
@@ -110,9 +110,9 @@ namespace NUnit.Framework.Internal.Execution
             return sorted;
         }
 
-        private static Dictionary<Test, Test?>? PrepareTestDependencies(TestSuite suite)
+        private static Dictionary<ITest, ITest>? PrepareTestDependencies(TestSuite suite)
         {
-            var fixturesByType = new Dictionary<Type, Test>();
+            var fixturesByType = new Dictionary<Type, Test>(suite.Tests.Count);
             var dependencyByFixture = new Dictionary<Test, Type>();
 
             foreach (var child in suite.Tests)
@@ -133,7 +133,7 @@ namespace NUnit.Framework.Internal.Execution
             }
 
             // Build the dependency graph, which maps each fixture to its dependent fixture (if any)
-            var dependencyGraph = new Dictionary<Test, Test?>(suite.Tests.Count);
+            var dependencyGraph = new Dictionary<ITest, ITest>(suite.Tests.Count);
 
             foreach (var child in suite.Tests)
             {
@@ -146,24 +146,11 @@ namespace NUnit.Framework.Internal.Execution
                     dependencyGraph[fixture] = dependencyFixture;
                     fixture.DependantTest = dependencyFixture;
                 }
-                else
-                {
-                    dependencyGraph[fixture] = null;
-                }
             }
 
             // Validate dependency graph
             MarkInvalidDependenciesAsInvalid(fixturesByType, dependencyByFixture);
             MarkDependencyFeatureConflictsAsInvalid(dependencyGraph);
-
-            // Update the graph to reflect any dependencies found to be invalid
-            foreach (var test in dependencyByFixture.Keys)
-            {
-                if (test.RunState != RunState.Runnable || dependencyGraph[test]?.RunState != RunState.Runnable)
-                {
-                    dependencyGraph[test] = null;
-                }
-            }
 
             return dependencyGraph;
         }
@@ -240,7 +227,7 @@ namespace NUnit.Framework.Internal.Execution
             }
         }
 
-        private static void MarkDependencyFeatureConflictsAsInvalid(Dictionary<Test, Test?> dependencyGraph)
+        private static void MarkDependencyFeatureConflictsAsInvalid(Dictionary<ITest, ITest> dependencyGraph)
         {
             const string orderReason = "Fixture may not participate in both DependsOn and Order chains.";
             const string parallelReason = "Fixture dependency chains may not include fixtures configured for parallel execution.";

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -81,7 +81,7 @@ namespace NUnit.Framework.Internal.Execution
                     }
                 }
 
-                if (countOrderedItems > 0)
+                if (countOrderedItems > 1)
                     work!.Children.Sort(0, countOrderedItems, new WorkItemOrderComparer());
 
                 if (work is not null)

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -122,7 +122,7 @@ namespace NUnit.Framework.Internal.Execution
 
                 fixturesByType[fixture.TypeInfo.Type] = fixture;
 
-                if (fixture.Properties.Get(PropertyNames.DependsOnType) is Type dependencyType)
+                if (fixture.Properties.Get(PropertyNames.DependsOnFixture) is Type dependencyType)
                     dependencyByFixture[fixture] = dependencyType;
             }
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -55,11 +55,12 @@ namespace NUnit.Framework.Internal.Execution
 
             if (recursive)
             {
-                PrepareFixtureDependencies(suite);
+                var testDependencies = PrepareTestDependencies(suite);
+                var sortedDependencies = TopologicalSort(testDependencies);
 
                 int countOrderedItems = 0;
 
-                foreach (var childTest in suite.Tests)
+                foreach (var childTest in sortedDependencies)
                 {
                     var childItem = CreateWorkItem(childTest, filter, debugger, recursive, root: false);
                     if (childItem is null)
@@ -83,20 +84,38 @@ namespace NUnit.Framework.Internal.Execution
 
                 if (countOrderedItems > 1)
                     work!.Children.Sort(0, countOrderedItems, new WorkItemOrderComparer());
-
-                if (work is not null)
-                    ReorderChildrenByDependency(work.Children);
             }
             return work;
         }
 
-        private static void PrepareFixtureDependencies(TestSuite suite)
+        private static List<ITest> TopologicalSort(Dictionary<ITest, ITest?> dependencyGraph)
+        {
+            var sorted = new List<ITest>();
+            var visited = new HashSet<ITest>();
+            foreach (var fixture in dependencyGraph.Keys)
+                Visit(fixture);
+            void Visit(ITest fixture)
+            {
+                if (!visited.Add(fixture))
+                    return;
+                if (dependencyGraph.TryGetValue(fixture, out ITest? dependency) && dependency is not null)
+                    Visit(dependency);
+                sorted.Add(fixture);
+            }
+            return sorted;
+        }
+
+        private static Dictionary<ITest, ITest?> PrepareTestDependencies(TestSuite suite)
         {
             var fixturesByType = new Dictionary<Type, Test>();
             var dependencyByFixture = new Dictionary<Test, Type>();
 
+            var dependencyGraph = new Dictionary<ITest, ITest?>();
+
             foreach (var child in suite.Tests)
             {
+                dependencyGraph[child] = null;
+
                 if (child is not Test fixture || fixture.TypeInfo?.Type is null)
                     continue;
 
@@ -108,6 +127,20 @@ namespace NUnit.Framework.Internal.Execution
 
             MarkInvalidDependenciesAsInvalid(fixturesByType, dependencyByFixture);
             MarkDependencyFeatureConflictsAsInvalid(fixturesByType, dependencyByFixture);
+
+            foreach (var pair in dependencyByFixture)
+            {
+                var fixture = pair.Key;
+
+                if (fixture.RunState == RunState.Runnable
+                    && fixturesByType.TryGetValue(pair.Value, out Test? dependencyFixture)
+                    && dependencyFixture.RunState == RunState.Runnable)
+                {
+                    dependencyGraph[fixture] = dependencyFixture;
+                }
+            }
+
+            return dependencyGraph;
         }
 
         private static void MarkInvalidDependenciesAsInvalid(Dictionary<Type, Test> fixturesByType, Dictionary<Test, Type> dependencyByFixture)
@@ -209,54 +242,6 @@ namespace NUnit.Framework.Internal.Execution
                 return scope.HasFlag(ParallelScope.Self) && !scope.HasFlag(ParallelScope.None);
             }
         }
-
-        private static void ReorderChildrenByDependency(List<WorkItem> children)
-        {
-            if (children.Count < 2)
-                return;
-
-            bool moved;
-            int remainingPasses = children.Count * children.Count;
-
-            do
-            {
-                moved = false;
-
-                var indexByType = new Dictionary<Type, int>();
-                for (int i = 0; i < children.Count; i++)
-                {
-                    if (children[i].Test is Test fixture && fixture.TypeInfo?.Type is Type fixtureType)
-                        indexByType[fixtureType] = i;
-                }
-
-                for (int i = 0; i < children.Count; i++)
-                {
-                    if (children[i].Test is not Test fixture || fixture.RunState == RunState.NotRunnable || fixture.Properties.Get(PropertyNames.DependsOn) is not Type dependencyType)
-                        continue;
-
-                    if (!indexByType.TryGetValue(dependencyType, out int dependencyIndex) || dependencyIndex < i)
-                        continue;
-
-                    if (children[dependencyIndex].Test is Test dependencyFixture && dependencyFixture.RunState == RunState.NotRunnable)
-                        continue;
-
-                    if (dependencyIndex == i)
-                        continue;
-
-                    var dependentChild = children[i];
-                    children.RemoveAt(i);
-
-                    if (dependencyIndex > i)
-                        dependencyIndex--;
-
-                    children.Insert(dependencyIndex + 1, dependentChild);
-                    moved = true;
-                    break;
-                }
-            }
-            while (moved && remainingPasses-- > 0);
-        }
-
         #endregion
 
         private class WorkItemOrderComparer : IComparer<WorkItem>

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -106,11 +106,11 @@ namespace NUnit.Framework.Internal.Execution
                     dependencyByFixture[fixture] = dependencyType;
             }
 
-            MarkCircularDependenciesAsInvalid(fixturesByType, dependencyByFixture);
-            MarkDependencyConflictsAsInvalid(fixturesByType, dependencyByFixture);
+            MarkInvalidDependenciesAsInvalid(fixturesByType, dependencyByFixture);
+            MarkDependencyFeatureConflictsAsInvalid(fixturesByType, dependencyByFixture);
         }
 
-        private static void MarkCircularDependenciesAsInvalid(Dictionary<Type, Test> fixturesByType, Dictionary<Test, Type> dependencyByFixture)
+        private static void MarkInvalidDependenciesAsInvalid(Dictionary<Type, Test> fixturesByType, Dictionary<Test, Type> dependencyByFixture)
         {
             const string directReferenceReason = "Circular or self-referential test dependency detected.";
             const string baseReferenceReason = "Circular or self-referential test dependency detected via base class.";
@@ -153,6 +153,11 @@ namespace NUnit.Framework.Internal.Execution
                         if (invalidCircularDependencies.Contains(dependencyFixture))
                             MarkInvalidCircularDependency(fixture, directReferenceReason);
                     }
+                    else
+                    {
+                        // Dependency not found in the suite
+                        fixture.MakeInvalid($"Test dependency {dependencyType} can not be found. Please verify it was configured correctly and was not filtered out.");
+                    }
                 }
 
                 stack.RemoveAt(stack.Count - 1);
@@ -180,7 +185,7 @@ namespace NUnit.Framework.Internal.Execution
             }
         }
 
-        private static void MarkDependencyConflictsAsInvalid(Dictionary<Type, Test> fixturesByType, Dictionary<Test, Type> dependencyByFixture)
+        private static void MarkDependencyFeatureConflictsAsInvalid(Dictionary<Type, Test> fixturesByType, Dictionary<Test, Type> dependencyByFixture)
         {
             const string orderReason = "Fixture may not participate in both DependsOn and Order chains.";
             const string parallelReason = "Fixture dependency chains may not include fixtures configured for parallel execution.";

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -88,7 +88,7 @@ namespace NUnit.Framework.Internal.Execution
             return work;
         }
 
-        private static List<ITest> TopologicalSort(Dictionary<ITest, ITest?> dependencyGraph)
+        private static List<ITest> TopologicalSort(Dictionary<Test, Test?> dependencyGraph)
         {
             var sorted = new List<ITest>(dependencyGraph.Count);
             var visited = new HashSet<ITest>();
@@ -96,12 +96,12 @@ namespace NUnit.Framework.Internal.Execution
             foreach (var fixture in dependencyGraph.Keys)
                 Visit(fixture);
 
-            void Visit(ITest fixture)
+            void Visit(Test fixture)
             {
                 if (!visited.Add(fixture))
                     return;
 
-                if (dependencyGraph.TryGetValue(fixture, out ITest? dependency) && dependency is not null)
+                if (dependencyGraph.TryGetValue(fixture, out Test? dependency) && dependency is not null)
                     Visit(dependency);
 
                 sorted.Add(fixture);
@@ -110,7 +110,7 @@ namespace NUnit.Framework.Internal.Execution
             return sorted;
         }
 
-        private static Dictionary<ITest, ITest?>? PrepareTestDependencies(TestSuite suite)
+        private static Dictionary<Test, Test?>? PrepareTestDependencies(TestSuite suite)
         {
             var fixturesByType = new Dictionary<Type, Test>();
             var dependencyByFixture = new Dictionary<Test, Type>();
@@ -132,7 +132,8 @@ namespace NUnit.Framework.Internal.Execution
                 return null;
             }
 
-            var dependencyGraph = new Dictionary<ITest, ITest?>(suite.Tests.Count);
+            // Build the dependency graph, which maps each fixture to its dependent fixture (if any)
+            var dependencyGraph = new Dictionary<Test, Test?>(suite.Tests.Count);
 
             foreach (var child in suite.Tests)
             {
@@ -142,26 +143,25 @@ namespace NUnit.Framework.Internal.Execution
                 if (dependencyByFixture.TryGetValue(fixture, out Type? dependencyType)
                     && fixturesByType.TryGetValue(dependencyType, out Test? dependencyFixture))
                 {
-                    dependencyGraph[child] = dependencyFixture;
+                    dependencyGraph[fixture] = dependencyFixture;
+                    fixture.DependantTest = dependencyFixture;
                 }
                 else
                 {
-                    dependencyGraph[child] = null;
+                    dependencyGraph[fixture] = null;
                 }
             }
 
+            // Validate dependency graph
             MarkInvalidDependenciesAsInvalid(fixturesByType, dependencyByFixture);
             MarkDependencyFeatureConflictsAsInvalid(dependencyGraph);
 
-            foreach (var pair in dependencyByFixture)
+            // Update the graph to reflect any dependencies found to be invalid
+            foreach (var test in dependencyByFixture.Keys)
             {
-                var fixture = pair.Key;
-
-                if (fixture.RunState != RunState.Runnable
-                    || !fixturesByType.TryGetValue(pair.Value, out Test? dependencyFixture)
-                    || dependencyFixture.RunState != RunState.Runnable)
+                if (test.RunState != RunState.Runnable || dependencyGraph[test]?.RunState != RunState.Runnable)
                 {
-                    dependencyGraph[fixture] = null;
+                    dependencyGraph[test] = null;
                 }
             }
 
@@ -240,35 +240,32 @@ namespace NUnit.Framework.Internal.Execution
             }
         }
 
-        private static void MarkDependencyFeatureConflictsAsInvalid(Dictionary<ITest, ITest?> dependencyGraph)
+        private static void MarkDependencyFeatureConflictsAsInvalid(Dictionary<Test, Test?> dependencyGraph)
         {
             const string orderReason = "Fixture may not participate in both DependsOn and Order chains.";
             const string parallelReason = "Fixture dependency chains may not include fixtures configured for parallel execution.";
 
             foreach (var pair in dependencyGraph)
             {
-                if (pair.Key is not Test fixture || pair.Value is not Test dependencyFixture)
+                if (pair.Key is not Test test || pair.Value is not Test dependantTest)
                     continue;
 
-                MarkDependencyFeatureConflictsAsInvalid(fixture);
-                MarkDependencyFeatureConflictsAsInvalid(dependencyFixture);
+                MarkDependencyFeatureConflictsAsInvalid(test);
+                MarkDependencyFeatureConflictsAsInvalid(dependantTest);
             }
 
-            static void MarkDependencyFeatureConflictsAsInvalid(Test? fixture)
+            static void MarkDependencyFeatureConflictsAsInvalid(Test test)
             {
-                if (fixture is null)
-                    return;
+                if (test.Properties.ContainsKey(PropertyNames.Order))
+                    test.MakeInvalid(orderReason);
 
-                if (fixture.Properties.ContainsKey(PropertyNames.Order))
-                    fixture.MakeInvalid(orderReason);
-
-                if (IsConfiguredParallelWithOtherFixtures(fixture))
-                    fixture.MakeInvalid(parallelReason);
+                if (IsConfiguredParallelWithOtherFixtures(test))
+                    test.MakeInvalid(parallelReason);
             }
 
-            static bool IsConfiguredParallelWithOtherFixtures(Test fixture)
+            static bool IsConfiguredParallelWithOtherFixtures(Test test)
             {
-                var scope = fixture.Properties.TryGet(PropertyNames.ParallelScope, ParallelScope.Default);
+                var scope = test.GetEffectiveProperty(PropertyNames.ParallelScope, ParallelScope.Default);
                 return scope.HasFlag(ParallelScope.Self) && !scope.HasFlag(ParallelScope.None);
             }
         }

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -56,11 +56,11 @@ namespace NUnit.Framework.Internal.Execution
             if (recursive)
             {
                 var testDependencies = PrepareTestDependencies(suite);
-                var sortedDependencies = TopologicalSort(testDependencies);
+                var children = testDependencies is null ? suite.Tests : TopologicalSort(testDependencies);
 
                 int countOrderedItems = 0;
 
-                foreach (var childTest in sortedDependencies)
+                foreach (var childTest in children)
                 {
                     var childItem = CreateWorkItem(childTest, filter, debugger, recursive, root: false);
                     if (childItem is null)
@@ -90,32 +90,33 @@ namespace NUnit.Framework.Internal.Execution
 
         private static List<ITest> TopologicalSort(Dictionary<ITest, ITest?> dependencyGraph)
         {
-            var sorted = new List<ITest>();
+            var sorted = new List<ITest>(dependencyGraph.Count);
             var visited = new HashSet<ITest>();
+
             foreach (var fixture in dependencyGraph.Keys)
                 Visit(fixture);
+
             void Visit(ITest fixture)
             {
                 if (!visited.Add(fixture))
                     return;
+
                 if (dependencyGraph.TryGetValue(fixture, out ITest? dependency) && dependency is not null)
                     Visit(dependency);
+
                 sorted.Add(fixture);
             }
+
             return sorted;
         }
 
-        private static Dictionary<ITest, ITest?> PrepareTestDependencies(TestSuite suite)
+        private static Dictionary<ITest, ITest?>? PrepareTestDependencies(TestSuite suite)
         {
             var fixturesByType = new Dictionary<Type, Test>();
             var dependencyByFixture = new Dictionary<Test, Type>();
 
-            var dependencyGraph = new Dictionary<ITest, ITest?>();
-
             foreach (var child in suite.Tests)
             {
-                dependencyGraph[child] = null;
-
                 if (child is not Test fixture || fixture.TypeInfo?.Type is null)
                     continue;
 
@@ -125,10 +126,28 @@ namespace NUnit.Framework.Internal.Execution
                     dependencyByFixture[fixture] = dependencyType;
             }
 
-            foreach (var pair in dependencyByFixture)
+            // No need to create a dependency graph if there are no dependencies
+            if (dependencyByFixture.Count == 0)
             {
-                if (fixturesByType.TryGetValue(pair.Value, out Test? dependencyFixture))
-                    dependencyGraph[pair.Key] = dependencyFixture;
+                return null;
+            }
+
+            var dependencyGraph = new Dictionary<ITest, ITest?>(suite.Tests.Count);
+
+            foreach (var child in suite.Tests)
+            {
+                if (child is not Test fixture || fixture.TypeInfo?.Type is null)
+                    continue;
+
+                if (dependencyByFixture.TryGetValue(fixture, out Type? dependencyType)
+                    && fixturesByType.TryGetValue(dependencyType, out Test? dependencyFixture))
+                {
+                    dependencyGraph[child] = dependencyFixture;
+                }
+                else
+                {
+                    dependencyGraph[child] = null;
+                }
             }
 
             MarkInvalidDependenciesAsInvalid(fixturesByType, dependencyByFixture);

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -112,6 +112,10 @@ namespace NUnit.Framework.Internal.Execution
 
         private static void MarkCircularDependenciesAsInvalid(Dictionary<Type, Test> fixturesByType, Dictionary<Test, Type> dependencyByFixture)
         {
+            const string directReferenceReason = "Circular or self-referential test dependency detected.";
+            const string baseReferenceReason = "Circular or self-referential test dependency detected via base class.";
+
+            var invalidCircularDependencies = new HashSet<Test>();
             var visited = new HashSet<Test>();
             var visiting = new HashSet<Test>();
             var stack = new List<Test>();
@@ -121,25 +125,33 @@ namespace NUnit.Framework.Internal.Execution
 
             void Visit(Test fixture)
             {
-                if (visited.Contains(fixture))
+                if (!visited.Add(fixture))
                     return;
 
-                visited.Add(fixture);
                 visiting.Add(fixture);
                 stack.Add(fixture);
 
-                if (dependencyByFixture.TryGetValue(fixture, out Type? dependencyType)
-                    && fixturesByType.TryGetValue(dependencyType, out Test? dependencyFixture))
+                if (dependencyByFixture.TryGetValue(fixture, out Type? dependencyType))
                 {
-                    if (visiting.Contains(dependencyFixture))
+                    if (IsSelfReferentialBaseDependency(fixture, dependencyType))
                     {
-                        int cycleStartIndex = stack.IndexOf(dependencyFixture);
-                        if (cycleStartIndex >= 0)
-                            MarkCycle(stack, cycleStartIndex);
+                        MarkInvalidCircularDependency(fixture, baseReferenceReason);
                     }
-                    else
+                    else if (fixturesByType.TryGetValue(dependencyType, out Test? dependencyFixture))
                     {
-                        Visit(dependencyFixture);
+                        if (visiting.Contains(dependencyFixture))
+                        {
+                            int cycleStartIndex = stack.IndexOf(dependencyFixture);
+                            if (cycleStartIndex >= 0)
+                                MarkCycle(stack, cycleStartIndex);
+                        }
+                        else
+                        {
+                            Visit(dependencyFixture);
+                        }
+
+                        if (invalidCircularDependencies.Contains(dependencyFixture))
+                            MarkInvalidCircularDependency(fixture, directReferenceReason);
                     }
                 }
 
@@ -147,12 +159,24 @@ namespace NUnit.Framework.Internal.Execution
                 visiting.Remove(fixture);
             }
 
-            static void MarkCycle(List<Test> dependencyPath, int cycleStartIndex)
+            static bool IsSelfReferentialBaseDependency(Test fixture, Type dependencyType)
             {
-                const string reason = "Circular DependsOn dependency detected.";
+                if (fixture.TypeInfo?.Type is not Type fixtureType)
+                    return false;
 
+                return fixtureType.IsSubclassOf(dependencyType);
+            }
+
+            void MarkInvalidCircularDependency(Test fixture, string reason)
+            {
+                if (invalidCircularDependencies.Add(fixture))
+                    fixture.MakeInvalid(reason);
+            }
+
+            void MarkCycle(List<Test> dependencyPath, int cycleStartIndex)
+            {
                 for (int i = cycleStartIndex; i < dependencyPath.Count; i++)
-                    dependencyPath[i].MakeInvalid(reason);
+                    MarkInvalidCircularDependency(dependencyPath[i], directReferenceReason);
             }
         }
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -107,6 +107,7 @@ namespace NUnit.Framework.Internal.Execution
             }
 
             MarkCircularDependenciesAsInvalid(fixturesByType, dependencyByFixture);
+            MarkDependencyAndOrderConflictsAsInvalid(fixturesByType, dependencyByFixture);
 
             foreach (var dependency in dependencyByFixture)
             {
@@ -161,6 +162,25 @@ namespace NUnit.Framework.Internal.Execution
 
                 for (int i = cycleStartIndex; i < dependencyPath.Count; i++)
                     dependencyPath[i].MakeInvalid(reason);
+            }
+        }
+
+        private static void MarkDependencyAndOrderConflictsAsInvalid(Dictionary<Type, Test> fixturesByType, Dictionary<Test, Type> dependencyByFixture)
+        {
+            const string reason = "Fixture may not participate in both DependsOn and Order chains.";
+
+            var dependencyParticipants = new HashSet<Test>(dependencyByFixture.Keys);
+
+            foreach (var dependency in dependencyByFixture.Values)
+            {
+                if (fixturesByType.TryGetValue(dependency, out Test? dependencyFixture))
+                    dependencyParticipants.Add(dependencyFixture);
+            }
+
+            foreach (var fixture in dependencyParticipants)
+            {
+                if (fixture.Properties.ContainsKey(PropertyNames.Order))
+                    fixture.MakeInvalid(reason);
             }
         }
 

--- a/src/NUnitFramework/framework/Internal/PropertyNames.cs
+++ b/src/NUnitFramework/framework/Internal/PropertyNames.cs
@@ -11,28 +11,28 @@ namespace NUnit.Framework.Internal
         #region Internal Properties
 
         /// <summary>
-        /// The FriendlyName of the AppDomain in which the assembly is running
+        /// The FriendlyName of the AppDomain in which the assembly is running.
         /// </summary>
         public const string AppDomain = "_APPDOMAIN";
 
         /// <summary>
-        /// The selected strategy for joining parameter data into test cases
+        /// The selected strategy for joining parameter data into test cases.
         /// </summary>
         public const string JoinType = "_JOINTYPE";
 
         /// <summary>
-        /// The process ID of the executing assembly
+        /// The process ID of the executing assembly.
         /// </summary>
         public const string ProcessId = "_PID";
 
         /// <summary>
-        /// The stack trace from any data provider that threw
+        /// The stack trace from any data provider that threw.
         /// an exception.
         /// </summary>
         public const string ProviderStackTrace = "_PROVIDERSTACKTRACE";
 
         /// <summary>
-        /// The reason a test was not run
+        /// The reason a test was not run.
         /// </summary>
         public const string SkipReason = "_SKIPREASON";
 
@@ -41,97 +41,97 @@ namespace NUnit.Framework.Internal
         #region Standard Properties
 
         /// <summary>
-        /// The author of the tests
+        /// The author of the tests.
         /// </summary>
         public const string Author = "Author";
 
         /// <summary>
-        /// The ApartmentState required for running the test
+        /// The ApartmentState required for running the test.
         /// </summary>
         public const string ApartmentState = "ApartmentState";
 
         /// <summary>
-        /// The categories applying to a test
+        /// The categories applying to a test.
         /// </summary>
         public const string Category = "Category";
 
         /// <summary>
-        /// The Description of a test
+        /// The Description of a test.
         /// </summary>
         public const string Description = "Description";
 
         /// <summary>
-        /// The number of threads to be used in running tests
+        /// The number of threads to be used in running tests.
         /// </summary>
         public const string LevelOfParallelism = "LevelOfParallelism";
 
         /// <summary>
-        /// The maximum time in ms, above which the test is considered to have failed
+        /// The maximum time in ms, above which the test is considered to have failed.
         /// </summary>
         public const string MaxTime = "MaxTime";
 
         /// <summary>
-        /// The ParallelScope associated with a test
+        /// The ParallelScope associated with a test.
         /// </summary>
         public const string ParallelScope = "ParallelScope";
 
         /// <summary>
-        /// The number of times the test should be repeated
+        /// The number of times the test should be repeated.
         /// </summary>
         public const string RepeatCount = "Repeat";
 
         /// <summary>
-        /// Indicates that the test should be run on a separate thread
+        /// Indicates that the test should be run on a separate thread.
         /// </summary>
         public const string RequiresThread = "RequiresThread";
 
         /// <summary>
-        /// The culture to be set for a test
+        /// The culture to be set for a test.
         /// </summary>
         public const string SetCulture = "SetCulture";
 
         /// <summary>
-        /// The UI culture to be set for a test
+        /// The UI culture to be set for a test.
         /// </summary>
         public const string SetUICulture = "SetUICulture";
 
         /// <summary>
-        /// The type that is under test
+        /// The type that is under test.
         /// </summary>
         public const string TestOf = "TestOf";
 
         /// <summary>
-        /// The timeout value for the test
+        /// The timeout value for the test.
         /// </summary>
         public const string Timeout = "Timeout";
 
         /// <summary>
-        /// The timeout value for the test
+        /// The timeout value for the test.
         /// </summary>
         public const string UseCancellation = "UseCancellation";
 
         /// <summary>
-        /// The test will be ignored until the given date
+        /// The test will be ignored until the given date.
         /// </summary>
         public const string IgnoreUntilDate = "IgnoreUntilDate";
 
         /// <summary>
-        /// The optional Order the test will run in
+        /// The optional Order the test will run in.
         /// </summary>
         public const string Order = "Order";
 
         /// <summary>
-        /// The fixture type that this fixture depends on
+        /// The fixture type that this fixture depends on.
         /// </summary>
         public const string DependsOn = "DependsOn";
 
         /// <summary>
-        /// Indicates whether the dependent fixture must succeed before the test can run
+        /// Indicates whether the dependent fixture is allowed to fail without affecting this fixture.
         /// </summary>
-        public const string DependsOnRequiresSuccess = $"{DependsOn}.RequiresSuccess";
+        public const string DependsOnAllowFailure = $"{DependsOn}.AllowFailure";
 
         /// <summary>
-        /// The default status for a test with no runnable children
+        /// The default status for a test with no runnable children.
         /// </summary>
         public const string NoTests = "NoTests";
 

--- a/src/NUnitFramework/framework/Internal/PropertyNames.cs
+++ b/src/NUnitFramework/framework/Internal/PropertyNames.cs
@@ -126,6 +126,11 @@ namespace NUnit.Framework.Internal
         public const string DependsOn = "DependsOn";
 
         /// <summary>
+        /// Indicates whether the dependent fixture must succeed before the test can run
+        /// </summary>
+        public const string DependsOnRequiresSuccess = "DependsOn.RequiresSuccess";
+
+        /// <summary>
         /// The default status for a test with no runnable children
         /// </summary>
         public const string NoTests = "NoTests";

--- a/src/NUnitFramework/framework/Internal/PropertyNames.cs
+++ b/src/NUnitFramework/framework/Internal/PropertyNames.cs
@@ -121,6 +121,11 @@ namespace NUnit.Framework.Internal
         public const string Order = "Order";
 
         /// <summary>
+        /// The fixture type that this fixture depends on
+        /// </summary>
+        public const string DependsOn = "DependsOn";
+
+        /// <summary>
         /// The default status for a test with no runnable children
         /// </summary>
         public const string NoTests = "NoTests";

--- a/src/NUnitFramework/framework/Internal/PropertyNames.cs
+++ b/src/NUnitFramework/framework/Internal/PropertyNames.cs
@@ -123,7 +123,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// The fixture type that this fixture depends on.
         /// </summary>
-        public const string DependsOnType = "DependsOn.Type";
+        public const string DependsOnFixture = "DependsOn.Fixture";
 
         /// <summary>
         /// Indicates whether the dependent fixture is allowed to fail without affecting this fixture.

--- a/src/NUnitFramework/framework/Internal/PropertyNames.cs
+++ b/src/NUnitFramework/framework/Internal/PropertyNames.cs
@@ -128,7 +128,7 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// Indicates whether the dependent fixture must succeed before the test can run
         /// </summary>
-        public const string DependsOnRequiresSuccess = "DependsOn.RequiresSuccess";
+        public const string DependsOnRequiresSuccess = $"{DependsOn}.RequiresSuccess";
 
         /// <summary>
         /// The default status for a test with no runnable children

--- a/src/NUnitFramework/framework/Internal/PropertyNames.cs
+++ b/src/NUnitFramework/framework/Internal/PropertyNames.cs
@@ -123,12 +123,12 @@ namespace NUnit.Framework.Internal
         /// <summary>
         /// The fixture type that this fixture depends on.
         /// </summary>
-        public const string DependsOn = "DependsOn";
+        public const string DependsOnType = "DependsOn.Type";
 
         /// <summary>
         /// Indicates whether the dependent fixture is allowed to fail without affecting this fixture.
         /// </summary>
-        public const string DependsOnAllowFailure = $"{DependsOn}.AllowFailure";
+        public const string DependsOnAllowFailure = $"DependsOn.AllowFailure";
 
         /// <summary>
         /// The default status for a test with no runnable children.

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -261,7 +261,7 @@ namespace NUnit.Framework.Internal
 
         #region Internal Properties
 
-        internal Test? DependantTest { get; set; }
+        internal ITest? DependantTest { get; set; }
 
         internal bool RequiresThread { get; set; }
 

--- a/src/NUnitFramework/framework/Internal/Tests/Test.cs
+++ b/src/NUnitFramework/framework/Internal/Tests/Test.cs
@@ -261,6 +261,8 @@ namespace NUnit.Framework.Internal
 
         #region Internal Properties
 
+        internal Test? DependantTest { get; set; }
+
         internal bool RequiresThread { get; set; }
 
         private ITestAction[]? _actions;

--- a/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
@@ -84,7 +84,7 @@ namespace NUnit.TestData
     }
 
     [TestFixture]
-    [DependsOn(typeof(FixtureDependencyBeforeFailing), RequiresSuccess = false)]
+    [DependsOn(typeof(FixtureDependencyBeforeFailing), AllowFailure = true)]
     public class FixtureDependencyAfterFailingAllowed : FixtureDependencyBase
     {
         [Test]

--- a/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
@@ -10,7 +10,7 @@ namespace NUnit.TestData
     {
         private static readonly object SyncRoot = new();
 
-        public static List<string> Events { get; } = new();
+        public static List<string> Events { get; } = [];
 
         public static void Reset()
         {

--- a/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
@@ -104,4 +104,38 @@ namespace NUnit.TestData
             FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyAfterFailing) + ".OneTimeTearDown");
         }
     }
+
+    [TestFixture]
+    [DependsOn(typeof(FixtureDependencyCycleB))]
+    public class FixtureDependencyCycleA
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyCycleA) + ".OneTimeSetUp");
+        }
+
+        [Test]
+        public void A()
+        {
+            Assert.Pass();
+        }
+    }
+
+    [TestFixture]
+    [DependsOn(typeof(FixtureDependencyCycleA))]
+    public class FixtureDependencyCycleB
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyCycleB) + ".OneTimeSetUp");
+        }
+
+        [Test]
+        public void B()
+        {
+            Assert.Pass();
+        }
+    }
 }

--- a/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
@@ -183,6 +183,23 @@ namespace NUnit.TestData
     }
 
     [TestFixture]
+    [DependsOn(typeof(FixtureDependencySelfReferential))]
+    public class FixtureDependencySelfReferential
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencySelfReferential) + ".OneTimeSetUp");
+        }
+
+        [Test]
+        public void B()
+        {
+            Assert.Pass();
+        }
+    }
+
+    [TestFixture]
     [DependsOn(typeof(FixtureDependencyOrderBefore))]
     [Order(1)]
     public class FixtureDependencyOrderAfter

--- a/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
@@ -152,8 +152,30 @@ namespace NUnit.TestData
     }
 
     [TestFixture]
+    [DependsOn(typeof(FixtureDependencyCycleA))]
+    public class FixtureDependencyCycleReferrer : FixtureDependencyBase
+    {
+        [Test]
+        public void C()
+        {
+            Assert.That(true, Is.True);
+        }
+    }
+
+    [TestFixture]
     [DependsOn(typeof(FixtureDependencySelfReferential))]
     public class FixtureDependencySelfReferential
+    {
+        [Test]
+        public void B()
+        {
+            Assert.That(true, Is.True);
+        }
+    }
+
+    [TestFixture]
+    [DependsOn(typeof(FixtureDependencyBase))]
+    public class FixtureDependencySelfReferentialBase : FixtureDependencyBase
     {
         [Test]
         public void B()

--- a/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
@@ -116,6 +116,29 @@ namespace NUnit.TestData
     }
 
     [TestFixture]
+    [DependsOn(typeof(FixtureDependencyBeforeFailing), RequiresSuccess = false)]
+    public class FixtureDependencyAfterFailingAllowed
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyAfterFailingAllowed) + ".OneTimeSetUp");
+        }
+
+        [Test]
+        public void AfterFailingDependencyAllowedTest()
+        {
+            Assert.Pass();
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyAfterFailingAllowed) + ".OneTimeTearDown");
+        }
+    }
+
+    [TestFixture]
     [DependsOn(typeof(FixtureDependencyCycleB))]
     public class FixtureDependencyCycleA
     {

--- a/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace NUnit.TestData
+{
+    public static class FixtureDependencyEvents
+    {
+        public static List<string> Events { get; } = new();
+
+        public static void Reset()
+        {
+            Events.Clear();
+        }
+    }
+
+    [TestFixture]
+    public class FixtureDependencyBefore
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyBefore) + ".OneTimeSetUp");
+        }
+
+        [Test]
+        public void BeforeTest()
+        {
+            Assert.Pass();
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyBefore) + ".OneTimeTearDown");
+        }
+    }
+
+    [TestFixture]
+    [DependsOn(typeof(FixtureDependencyBefore))]
+    public class FixtureDependencyAfter
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyAfter) + ".OneTimeSetUp");
+        }
+
+        [Test]
+        public void AfterTest()
+        {
+            Assert.Pass();
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyAfter) + ".OneTimeTearDown");
+        }
+    }
+
+    [TestFixture]
+    public class FixtureDependencyBeforeFailing
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyBeforeFailing) + ".OneTimeSetUp");
+        }
+
+        [Test]
+        public void BeforeFailingTest()
+        {
+            Assert.Fail("Intentional failure for dependency behavior testing");
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyBeforeFailing) + ".OneTimeTearDown");
+        }
+    }
+
+    [TestFixture]
+    [DependsOn(typeof(FixtureDependencyBeforeFailing))]
+    public class FixtureDependencyAfterFailing
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyAfterFailing) + ".OneTimeSetUp");
+        }
+
+        [Test]
+        public void AfterFailingDependencyTest()
+        {
+            Assert.Pass();
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyAfterFailing) + ".OneTimeTearDown");
+        }
+    }
+}

--- a/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
@@ -1,17 +1,27 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System.Collections.Generic;
+using System.Threading;
 using NUnit.Framework;
 
 namespace NUnit.TestData
 {
     public static class FixtureDependencyEvents
     {
+        private static readonly object SyncRoot = new();
+
         public static List<string> Events { get; } = new();
 
         public static void Reset()
         {
-            Events.Clear();
+            lock (SyncRoot)
+                Events.Clear();
+        }
+
+        public static void Record(string value)
+        {
+            lock (SyncRoot)
+                Events.Add(value);
         }
     }
 
@@ -178,6 +188,65 @@ namespace NUnit.TestData
     {
         [Test]
         public void Referrer()
+        {
+            Assert.Pass();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    public class FixtureDependencyParallelBeforeSlow
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            FixtureDependencyEvents.Record(nameof(FixtureDependencyParallelBeforeSlow) + ".OneTimeSetUp");
+        }
+
+        [Test]
+        public void BeforeSlowTest()
+        {
+            Thread.Sleep(150);
+            Assert.Pass();
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            FixtureDependencyEvents.Record(nameof(FixtureDependencyParallelBeforeSlow) + ".OneTimeTearDown");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    [DependsOn(typeof(FixtureDependencyParallelBeforeSlow))]
+    public class FixtureDependencyParallelAfter
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            FixtureDependencyEvents.Record(nameof(FixtureDependencyParallelAfter) + ".OneTimeSetUp");
+        }
+
+        [Test]
+        public void AfterParallelDependency()
+        {
+            Assert.Pass();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    public class FixtureDependencyParallelIndependent
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            FixtureDependencyEvents.Record(nameof(FixtureDependencyParallelIndependent) + ".OneTimeSetUp");
+        }
+
+        [Test]
+        public void IndependentTest()
         {
             Assert.Pass();
         }

--- a/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
@@ -30,13 +30,15 @@ namespace NUnit.TestData
         [OneTimeSetUp]
         public void SetUp()
         {
-            FixtureDependencyEvents.Record(GetType().Name + ".OneTimeSetUp");
+            var testName = TestContext.CurrentContext.Test.Name;
+            FixtureDependencyEvents.Record($"{testName}.OneTimeSetUp");
         }
 
         [OneTimeTearDown]
         public void TearDown()
         {
-            FixtureDependencyEvents.Record(GetType().Name + ".OneTimeTearDown");
+            var testName = TestContext.CurrentContext.Test.Name;
+            FixtureDependencyEvents.Record($"{testName}.OneTimeTearDown");
         }
     }
 

--- a/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
@@ -138,4 +138,48 @@ namespace NUnit.TestData
             Assert.Pass();
         }
     }
+
+    [TestFixture]
+    public class FixtureDependencyOrderBefore
+    {
+        [Test]
+        public void Before()
+        {
+            Assert.Pass();
+        }
+    }
+
+    [TestFixture]
+    [DependsOn(typeof(FixtureDependencyOrderBefore))]
+    [Order(1)]
+    public class FixtureDependencyOrderAfter
+    {
+        [Test]
+        public void After()
+        {
+            Assert.Pass();
+        }
+    }
+
+    [TestFixture]
+    [Order(2)]
+    public class FixtureDependencyOrderTarget
+    {
+        [Test]
+        public void Target()
+        {
+            Assert.Pass();
+        }
+    }
+
+    [TestFixture]
+    [DependsOn(typeof(FixtureDependencyOrderTarget))]
+    public class FixtureDependencyOrderReferrer
+    {
+        [Test]
+        public void Referrer()
+        {
+            Assert.Pass();
+        }
+    }
 }

--- a/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/FixtureDependsOnAttributeFixture.cs
@@ -25,25 +25,29 @@ namespace NUnit.TestData
         }
     }
 
-    [TestFixture]
-    public class FixtureDependencyBefore
+    public class FixtureDependencyBase
     {
         [OneTimeSetUp]
         public void SetUp()
         {
-            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyBefore) + ".OneTimeSetUp");
-        }
-
-        [Test]
-        public void BeforeTest()
-        {
-            Assert.Pass();
+            FixtureDependencyEvents.Record(GetType().Name + ".OneTimeSetUp");
         }
 
         [OneTimeTearDown]
         public void TearDown()
         {
-            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyBefore) + ".OneTimeTearDown");
+            FixtureDependencyEvents.Record(GetType().Name + ".OneTimeTearDown");
+        }
+    }
+
+    #region Basic Functionality
+    [TestFixture]
+    public class FixtureDependencyBefore
+    {
+        [Test]
+        public void BeforeTest()
+        {
+            Assert.That(true, Is.True);
         }
     }
 
@@ -51,107 +55,88 @@ namespace NUnit.TestData
     [DependsOn(typeof(FixtureDependencyBefore))]
     public class FixtureDependencyAfter
     {
-        [OneTimeSetUp]
-        public void SetUp()
-        {
-            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyAfter) + ".OneTimeSetUp");
-        }
-
         [Test]
         public void AfterTest()
         {
-            Assert.Pass();
-        }
-
-        [OneTimeTearDown]
-        public void TearDown()
-        {
-            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyAfter) + ".OneTimeTearDown");
+            Assert.That(true, Is.True);
         }
     }
 
     [TestFixture]
-    public class FixtureDependencyBeforeFailing
+    public class FixtureDependencyBeforeFailing : FixtureDependencyBase
     {
-        [OneTimeSetUp]
-        public void SetUp()
-        {
-            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyBeforeFailing) + ".OneTimeSetUp");
-        }
-
         [Test]
         public void BeforeFailingTest()
         {
             Assert.Fail("Intentional failure for dependency behavior testing");
         }
-
-        [OneTimeTearDown]
-        public void TearDown()
-        {
-            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyBeforeFailing) + ".OneTimeTearDown");
-        }
     }
 
     [TestFixture]
     [DependsOn(typeof(FixtureDependencyBeforeFailing))]
-    public class FixtureDependencyAfterFailing
+    public class FixtureDependencyAfterFailing : FixtureDependencyBase
     {
-        [OneTimeSetUp]
-        public void SetUp()
-        {
-            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyAfterFailing) + ".OneTimeSetUp");
-        }
-
         [Test]
         public void AfterFailingDependencyTest()
         {
-            Assert.Pass();
-        }
-
-        [OneTimeTearDown]
-        public void TearDown()
-        {
-            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyAfterFailing) + ".OneTimeTearDown");
+            Assert.That(true, Is.True);
         }
     }
 
     [TestFixture]
     [DependsOn(typeof(FixtureDependencyBeforeFailing), RequiresSuccess = false)]
-    public class FixtureDependencyAfterFailingAllowed
+    public class FixtureDependencyAfterFailingAllowed : FixtureDependencyBase
     {
-        [OneTimeSetUp]
-        public void SetUp()
-        {
-            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyAfterFailingAllowed) + ".OneTimeSetUp");
-        }
-
         [Test]
         public void AfterFailingDependencyAllowedTest()
         {
-            Assert.Pass();
-        }
-
-        [OneTimeTearDown]
-        public void TearDown()
-        {
-            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyAfterFailingAllowed) + ".OneTimeTearDown");
+            Assert.That(true, Is.True);
         }
     }
 
     [TestFixture]
+    public class ForkingDependencyRoot : FixtureDependencyBase
+    {
+        [Test]
+        public void RootTest()
+        {
+            Assert.That(true, Is.True);
+        }
+    }
+
+    [TestFixture]
+    [DependsOn(typeof(ForkingDependencyRoot))]
+    public class ForkingDependencyNodeA : FixtureDependencyBase
+    {
+        [Test]
+        public void NodeATest()
+        {
+            Assert.That(true, Is.True);
+        }
+    }
+
+    [TestFixture]
+    [DependsOn(typeof(ForkingDependencyRoot))]
+    public class ForkingDependencyNodeB : FixtureDependencyBase
+    {
+        [Test]
+        public void NodeBTest()
+        {
+            Assert.That(true, Is.True);
+        }
+    }
+
+    #endregion
+
+    #region Referential Integrity
+    [TestFixture]
     [DependsOn(typeof(FixtureDependencyCycleB))]
     public class FixtureDependencyCycleA
     {
-        [OneTimeSetUp]
-        public void SetUp()
-        {
-            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyCycleA) + ".OneTimeSetUp");
-        }
-
         [Test]
         public void A()
         {
-            Assert.Pass();
+            Assert.That(true, Is.True);
         }
     }
 
@@ -159,26 +144,10 @@ namespace NUnit.TestData
     [DependsOn(typeof(FixtureDependencyCycleA))]
     public class FixtureDependencyCycleB
     {
-        [OneTimeSetUp]
-        public void SetUp()
-        {
-            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencyCycleB) + ".OneTimeSetUp");
-        }
-
         [Test]
         public void B()
         {
-            Assert.Pass();
-        }
-    }
-
-    [TestFixture]
-    public class FixtureDependencyOrderBefore
-    {
-        [Test]
-        public void Before()
-        {
-            Assert.Pass();
+            Assert.That(true, Is.True);
         }
     }
 
@@ -186,16 +155,22 @@ namespace NUnit.TestData
     [DependsOn(typeof(FixtureDependencySelfReferential))]
     public class FixtureDependencySelfReferential
     {
-        [OneTimeSetUp]
-        public void SetUp()
-        {
-            FixtureDependencyEvents.Events.Add(nameof(FixtureDependencySelfReferential) + ".OneTimeSetUp");
-        }
-
         [Test]
         public void B()
         {
-            Assert.Pass();
+            Assert.That(true, Is.True);
+        }
+    }
+    #endregion
+
+    #region Feature Compatibility
+    [TestFixture]
+    public class FixtureDependencyOrderBefore
+    {
+        [Test]
+        public void Before()
+        {
+            Assert.That(true, Is.True);
         }
     }
 
@@ -207,7 +182,7 @@ namespace NUnit.TestData
         [Test]
         public void After()
         {
-            Assert.Pass();
+            Assert.That(true, Is.True);
         }
     }
 
@@ -218,7 +193,7 @@ namespace NUnit.TestData
         [Test]
         public void Target()
         {
-            Assert.Pass();
+            Assert.That(true, Is.True);
         }
     }
 
@@ -229,7 +204,7 @@ namespace NUnit.TestData
         [Test]
         public void Referrer()
         {
-            Assert.Pass();
+            Assert.That(true, Is.True);
         }
     }
 
@@ -237,23 +212,11 @@ namespace NUnit.TestData
     [Parallelizable(ParallelScope.All)]
     public class FixtureDependencyParallelBeforeSlow
     {
-        [OneTimeSetUp]
-        public void SetUp()
-        {
-            FixtureDependencyEvents.Record(nameof(FixtureDependencyParallelBeforeSlow) + ".OneTimeSetUp");
-        }
-
         [Test]
         public void BeforeSlowTest()
         {
             Thread.Sleep(150);
-            Assert.Pass();
-        }
-
-        [OneTimeTearDown]
-        public void TearDown()
-        {
-            FixtureDependencyEvents.Record(nameof(FixtureDependencyParallelBeforeSlow) + ".OneTimeTearDown");
+            Assert.That(true, Is.True);
         }
     }
 
@@ -262,16 +225,10 @@ namespace NUnit.TestData
     [DependsOn(typeof(FixtureDependencyParallelBeforeSlow))]
     public class FixtureDependencyParallelAfter
     {
-        [OneTimeSetUp]
-        public void SetUp()
-        {
-            FixtureDependencyEvents.Record(nameof(FixtureDependencyParallelAfter) + ".OneTimeSetUp");
-        }
-
         [Test]
         public void AfterParallelDependency()
         {
-            Assert.Pass();
+            Assert.That(true, Is.True);
         }
     }
 
@@ -279,16 +236,11 @@ namespace NUnit.TestData
     [Parallelizable(ParallelScope.All)]
     public class FixtureDependencyParallelIndependent
     {
-        [OneTimeSetUp]
-        public void SetUp()
-        {
-            FixtureDependencyEvents.Record(nameof(FixtureDependencyParallelIndependent) + ".OneTimeSetUp");
-        }
-
         [Test]
         public void IndependentTest()
         {
-            Assert.Pass();
+            Assert.That(true, Is.True);
         }
     }
+    #endregion
 }

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -39,7 +39,7 @@ namespace NUnit.Framework.Tests.Attributes
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(fixture.Properties.Get(PropertyNames.DependsOn), Is.EqualTo(typeof(FixtureDependencyBefore)));
+                Assert.That(fixture.Properties.Get(PropertyNames.DependsOnType), Is.EqualTo(typeof(FixtureDependencyBefore)));
                 Assert.That(fixture.Properties.Get(PropertyNames.DependsOnAllowFailure), Is.False);
             }
         }

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Tests.Attributes
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(fixture.Properties.Get(PropertyNames.DependsOn), Is.EqualTo(typeof(FixtureDependencyBefore)));
-                Assert.That(fixture.Properties.Get(PropertyNames.DependsOnRequiresSuccess), Is.True);
+                Assert.That(fixture.Properties.Get(PropertyNames.DependsOnAllowFailure), Is.False);
             }
         }
 

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -41,7 +41,7 @@ namespace NUnit.Framework.Tests.Attributes
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(fixture.Properties.Get(PropertyNames.DependsOnType), Is.EqualTo(typeof(FixtureDependencyBefore)));
+                Assert.That(fixture.Properties.Get(PropertyNames.DependsOnFixture), Is.EqualTo(typeof(FixtureDependencyBefore)));
                 Assert.That(fixture.Properties.Get(PropertyNames.DependsOnAllowFailure), Is.False);
             }
         }

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -54,7 +54,7 @@ namespace NUnit.Framework.Tests.Attributes
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(work!.Children, Has.Count.EqualTo(2));
+                Assert.That(work.Children, Has.Count.EqualTo(2));
                 Assert.That(work.Children[0].Test.Name, Is.EqualTo(nameof(FixtureDependencyBefore)));
                 Assert.That(work.Children[1].Test.Name, Is.EqualTo(nameof(FixtureDependencyAfter)));
                 Assert.That(work.Children[0].ParallelScope, Is.EqualTo(ParallelScope.Default));

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -268,6 +268,26 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         [Test]
+        public void OrderAndDependsOnCoexistIndependently()
+        {
+            var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyAfter), typeof(FixtureDependencyBefore), typeof(FixtureDependencyOrderTarget));
+
+            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            var result = TestBuilder.ExecuteWorkItem(work!);
+
+            var dependencyAfter = result.Children.Single(x => x.Name == nameof(FixtureDependencyAfter));
+            var dependencyBefore = result.Children.Single(x => x.Name == nameof(FixtureDependencyBefore));
+            var order = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderTarget));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(dependencyBefore.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(dependencyAfter.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(order.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            }
+        }
+
+        [Test]
         public void ParallelConfiguredFixtureInvalidatesDependencyChain()
         {
             var suite = new TestSuite("dummy")

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -68,8 +68,6 @@ namespace NUnit.Framework.Tests.Attributes
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyAfterFailing), typeof(FixtureDependencyBeforeFailing));
 
             var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            Assert.That(work, Is.Not.Null);
-
             var result = TestBuilder.ExecuteWorkItem(work!);
 
             var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyBeforeFailing));
@@ -94,8 +92,6 @@ namespace NUnit.Framework.Tests.Attributes
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyAfterFailingAllowed), typeof(FixtureDependencyBeforeFailing));
 
             var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            Assert.That(work, Is.Not.Null);
-
             var result = TestBuilder.ExecuteWorkItem(work!);
 
             var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyBeforeFailing));
@@ -136,8 +132,6 @@ namespace NUnit.Framework.Tests.Attributes
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyCycleA), typeof(FixtureDependencyCycleB));
 
             var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            Assert.That(work, Is.Not.Null);
-
             var result = TestBuilder.ExecuteWorkItem(work!);
 
             var cycleAResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyCycleA));
@@ -149,8 +143,32 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(cycleBResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
                 Assert.That(cycleAResult.ResultState.Label, Is.EqualTo("Invalid"));
                 Assert.That(cycleBResult.ResultState.Label, Is.EqualTo("Invalid"));
-                Assert.That(cycleAResult.Message, Does.Contain("Circular DependsOn dependency detected."));
-                Assert.That(cycleBResult.Message, Does.Contain("Circular DependsOn dependency detected."));
+                Assert.That(cycleAResult.Message, Does.Contain("Circular or self-referential test dependency detected."));
+                Assert.That(cycleBResult.Message, Does.Contain("Circular or self-referential test dependency detected."));
+                Assert.That(FixtureDependencyEvents.Events, Is.Empty);
+            }
+        }
+
+        [Test]
+        public void FixtureReferencingCycleIsMarkedAsNotRunnable()
+        {
+            var suite = new TestSuite("dummy")
+                .Containing(typeof(FixtureDependencyCycleReferrer), typeof(FixtureDependencyCycleA), typeof(FixtureDependencyCycleB));
+
+            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            var result = TestBuilder.ExecuteWorkItem(work!);
+
+            var cycleReferrerResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyCycleReferrer));
+            var cycleAResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyCycleA));
+            var cycleBResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyCycleB));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(cycleReferrerResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(cycleAResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(cycleBResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(cycleReferrerResult.ResultState.Label, Is.EqualTo("Invalid"));
+                Assert.That(cycleReferrerResult.Message, Does.Contain("Circular or self-referential test dependency detected."));
                 Assert.That(FixtureDependencyEvents.Events, Is.Empty);
             }
         }
@@ -161,8 +179,6 @@ namespace NUnit.Framework.Tests.Attributes
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencySelfReferential));
 
             var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            Assert.That(work, Is.Not.Null);
-
             var result = TestBuilder.ExecuteWorkItem(work!);
 
             var selfReferentialResult = result.Children.Single(x => x.Name == nameof(FixtureDependencySelfReferential));
@@ -171,7 +187,26 @@ namespace NUnit.Framework.Tests.Attributes
             {
                 Assert.That(selfReferentialResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
                 Assert.That(selfReferentialResult.ResultState.Label, Is.EqualTo("Invalid"));
-                Assert.That(selfReferentialResult.Message, Does.Contain("Circular DependsOn dependency detected."));
+                Assert.That(selfReferentialResult.Message, Does.Contain("Circular or self-referential test dependency detected."));
+                Assert.That(FixtureDependencyEvents.Events, Is.Empty);
+            }
+        }
+
+        [Test]
+        public void SelfReferentialBaseMarksFixtureAsNotRunnable()
+        {
+            var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencySelfReferentialBase));
+
+            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            var result = TestBuilder.ExecuteWorkItem(work!);
+
+            var selfReferentialResult = result.Children.Single(x => x.Name == nameof(FixtureDependencySelfReferentialBase));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(selfReferentialResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(selfReferentialResult.ResultState.Label, Is.EqualTo("Invalid"));
+                Assert.That(selfReferentialResult.Message, Does.Contain("Circular or self-referential test dependency detected via base class."));
                 Assert.That(FixtureDependencyEvents.Events, Is.Empty);
             }
         }
@@ -182,8 +217,6 @@ namespace NUnit.Framework.Tests.Attributes
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyOrderBefore), typeof(FixtureDependencyOrderAfter));
 
             var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            Assert.That(work, Is.Not.Null);
-
             var result = TestBuilder.ExecuteWorkItem(work!);
 
             var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderBefore));
@@ -204,8 +237,6 @@ namespace NUnit.Framework.Tests.Attributes
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyOrderReferrer), typeof(FixtureDependencyOrderTarget));
 
             var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            Assert.That(work, Is.Not.Null);
-
             var result = TestBuilder.ExecuteWorkItem(work!);
 
             var referrerResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderReferrer));
@@ -237,8 +268,8 @@ namespace NUnit.Framework.Tests.Attributes
             var work = TestBuilder.CreateWorkItem(suite, context) as CompositeWorkItem;
             Assert.That(work, Is.Not.Null);
 
-            dispatcher.Start(work!);
-            work!.WaitForCompletion();
+            dispatcher.Start(work);
+            work.WaitForCompletion();
 
             var result = work.Result;
             var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyParallelBeforeSlow));

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -107,5 +107,49 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(FixtureDependencyEvents.Events, Is.Empty);
             });
         }
+
+        [Test]
+        public void FixtureUsingDependsOnAndOrderIsMarkedInvalid()
+        {
+            var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyOrderBefore), typeof(FixtureDependencyOrderAfter));
+
+            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            Assert.That(work, Is.Not.Null);
+
+            var result = TestBuilder.ExecuteWorkItem(work!);
+
+            var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderBefore));
+            var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderAfter));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(beforeResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(afterResult.ResultState.Label, Is.EqualTo("Invalid"));
+                Assert.That(afterResult.Message, Does.Contain("Fixture may not participate in both DependsOn and Order chains."));
+            });
+        }
+
+        [Test]
+        public void DependencyTargetWithOrderIsMarkedInvalid()
+        {
+            var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyOrderReferrer), typeof(FixtureDependencyOrderTarget));
+
+            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            Assert.That(work, Is.Not.Null);
+
+            var result = TestBuilder.ExecuteWorkItem(work!);
+
+            var referrerResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderReferrer));
+            var targetResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderTarget));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(referrerResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(targetResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(targetResult.ResultState.Label, Is.EqualTo("Invalid"));
+                Assert.That(targetResult.Message, Does.Contain("Fixture may not participate in both DependsOn and Order chains."));
+            });
+        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -40,7 +40,7 @@ namespace NUnit.Framework.Tests.Attributes
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(fixture.Properties.Get(PropertyNames.DependsOn), Is.EqualTo(typeof(FixtureDependencyBefore)));
-                Assert.That(fixture.Properties.Get(PropertyNames.DependsOnRequiresSuccess), Is.EqualTo(true));
+                Assert.That(fixture.Properties.Get(PropertyNames.DependsOnRequiresSuccess), Is.True);
             }
         }
 
@@ -110,6 +110,23 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
                 Assert.That(beforeTearDownIndex, Is.GreaterThanOrEqualTo(0));
                 Assert.That(afterSetUpIndex, Is.GreaterThan(beforeTearDownIndex));
+            }
+        }
+
+        [Test]
+        public void DependencyFixturesAreOrderedWhenDependeciesFork()
+        {
+            var suite = new TestSuite("dummy").Containing(typeof(ForkingDependencyRoot), typeof(ForkingDependencyNodeA), typeof(ForkingDependencyNodeB));
+
+            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            Assert.That(work, Is.Not.Null);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(work.Children, Has.Count.EqualTo(3));
+                Assert.That(work.Children[0].Test.Name, Is.EqualTo(nameof(ForkingDependencyRoot)));
+                Assert.That(work.Children[1].Test.Name, Is.EqualTo(nameof(ForkingDependencyNodeA)));
+                Assert.That(work.Children[2].Test.Name, Is.EqualTo(nameof(ForkingDependencyNodeB)));
             }
         }
 

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -22,7 +22,9 @@ namespace NUnit.Framework.Tests.Attributes
         [Test]
         public void AttributeUsageIsClassLevelSingleUse()
         {
-            var usage = (AttributeUsageAttribute)Attribute.GetCustomAttribute(typeof(DependsOnAttribute), typeof(AttributeUsageAttribute))!;
+            var usage = (AttributeUsageAttribute?)Attribute.GetCustomAttribute(typeof(DependsOnAttribute), typeof(AttributeUsageAttribute));
+
+            Assert.That(usage, Is.Not.Null, "DependsOnAttribute should have an AttributeUsage attribute.");
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -37,7 +37,11 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var fixture = TestBuilder.MakeFixture<FixtureDependencyAfter>();
 
-            Assert.That(fixture.Properties.Get(PropertyNames.DependsOn), Is.EqualTo(typeof(FixtureDependencyBefore)));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(fixture.Properties.Get(PropertyNames.DependsOn), Is.EqualTo(typeof(FixtureDependencyBefore)));
+                Assert.That(fixture.Properties.Get(PropertyNames.DependsOnRequiresSuccess), Is.EqualTo(true));
+            }
         }
 
         [Test]
@@ -81,6 +85,31 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(beforeTearDownIndex, Is.GreaterThanOrEqualTo(0));
                 // The dependent fixture should not have run at all, so its SetUp should not be in the events
                 Assert.That(afterSetUpIndex, Is.EqualTo(-1));
+            }
+        }
+
+        [Test]
+        public void DependentFixtureRunsWhenDependencyFailsAndRequiresSuccessIsFalse()
+        {
+            var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyAfterFailingAllowed), typeof(FixtureDependencyBeforeFailing));
+
+            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            Assert.That(work, Is.Not.Null);
+
+            var result = TestBuilder.ExecuteWorkItem(work!);
+
+            var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyBeforeFailing));
+            var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyAfterFailingAllowed));
+
+            var beforeTearDownIndex = FixtureDependencyEvents.Events.IndexOf(nameof(FixtureDependencyBeforeFailing) + ".OneTimeTearDown");
+            var afterSetUpIndex = FixtureDependencyEvents.Events.IndexOf(nameof(FixtureDependencyAfterFailingAllowed) + ".OneTimeSetUp");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(beforeResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(beforeTearDownIndex, Is.GreaterThanOrEqualTo(0));
+                Assert.That(afterSetUpIndex, Is.GreaterThan(beforeTearDownIndex));
             }
         }
 

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -47,20 +47,22 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         [Test]
-        public void DependencyFixturesAreOrderedAndMarkedNonParallel()
+        public void DependencyFixturesAreOrdered()
         {
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyAfter), typeof(FixtureDependencyBefore));
 
-            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            var work = (CompositeWorkItem)TestBuilder.CreateWorkItem(suite);
             Assert.That(work, Is.Not.Null);
 
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(work.Children, Has.Count.EqualTo(2));
+
+                Assert.That(suite.Tests[0].Name, Is.EqualTo(nameof(FixtureDependencyAfter)));
+                Assert.That(suite.Tests[1].Name, Is.EqualTo(nameof(FixtureDependencyBefore)));
+
                 Assert.That(work.Children[0].Test.Name, Is.EqualTo(nameof(FixtureDependencyBefore)));
                 Assert.That(work.Children[1].Test.Name, Is.EqualTo(nameof(FixtureDependencyAfter)));
-                Assert.That(work.Children[0].ParallelScope, Is.EqualTo(ParallelScope.Default));
-                Assert.That(work.Children[1].ParallelScope, Is.EqualTo(ParallelScope.Default));
             }
         }
 
@@ -69,8 +71,8 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyAfterFailing), typeof(FixtureDependencyBeforeFailing));
 
-            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            var result = TestBuilder.ExecuteWorkItem(work!);
+            var work = TestBuilder.CreateWorkItem(suite);
+            var result = TestBuilder.ExecuteWorkItem(work);
 
             var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyBeforeFailing));
             var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyAfterFailing));
@@ -84,13 +86,14 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(FixtureDependencyEvents.Events, Does.Not.Contain(afterResult.Name + ".OneTimeSetUp"));
             }
         }
+
         [Test]
         public void DependentFixtureIsNotRunnableIfDependencyAbsent()
         {
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyAfter));
 
-            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            var result = TestBuilder.ExecuteWorkItem(work!);
+            var work = TestBuilder.CreateWorkItem(suite);
+            var result = TestBuilder.ExecuteWorkItem(work);
 
             var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyAfter));
             var expectedMsg = $"Test dependency {typeof(FixtureDependencyBefore)} can not be found. Please verify it was configured correctly and was not filtered out.";
@@ -110,8 +113,8 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyAfterFailingAllowed), typeof(FixtureDependencyBeforeFailing));
 
-            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            var result = TestBuilder.ExecuteWorkItem(work!);
+            var work = TestBuilder.CreateWorkItem(suite);
+            var result = TestBuilder.ExecuteWorkItem(work);
 
             var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyBeforeFailing));
             var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyAfterFailingAllowed));
@@ -131,7 +134,7 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var suite = new TestSuite("dummy").Containing(typeof(ForkingDependencyRoot), typeof(ForkingDependencyNodeA), typeof(ForkingDependencyNodeB));
 
-            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            var work = (CompositeWorkItem)TestBuilder.CreateWorkItem(suite);
             Assert.That(work, Is.Not.Null);
 
             using (Assert.EnterMultipleScope())
@@ -148,8 +151,8 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyCycleA), typeof(FixtureDependencyCycleB));
 
-            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            var result = TestBuilder.ExecuteWorkItem(work!);
+            var work = TestBuilder.CreateWorkItem(suite);
+            var result = TestBuilder.ExecuteWorkItem(work);
 
             var cycleAResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyCycleA));
             var cycleBResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyCycleB));
@@ -172,8 +175,8 @@ namespace NUnit.Framework.Tests.Attributes
             var suite = new TestSuite("dummy")
                 .Containing(typeof(FixtureDependencyCycleReferrer), typeof(FixtureDependencyCycleA), typeof(FixtureDependencyCycleB));
 
-            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            var result = TestBuilder.ExecuteWorkItem(work!);
+            var work = TestBuilder.CreateWorkItem(suite);
+            var result = TestBuilder.ExecuteWorkItem(work);
 
             var cycleReferrerResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyCycleReferrer));
             var cycleAResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyCycleA));
@@ -195,8 +198,8 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencySelfReferential));
 
-            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            var result = TestBuilder.ExecuteWorkItem(work!);
+            var work = TestBuilder.CreateWorkItem(suite);
+            var result = TestBuilder.ExecuteWorkItem(work);
 
             var selfReferentialResult = result.Children.Single(x => x.Name == nameof(FixtureDependencySelfReferential));
 
@@ -214,8 +217,8 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencySelfReferentialBase));
 
-            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            var result = TestBuilder.ExecuteWorkItem(work!);
+            var work = TestBuilder.CreateWorkItem(suite);
+            var result = TestBuilder.ExecuteWorkItem(work);
 
             var selfReferentialResult = result.Children.Single(x => x.Name == nameof(FixtureDependencySelfReferentialBase));
 
@@ -233,8 +236,8 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyOrderBefore), typeof(FixtureDependencyOrderAfter));
 
-            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            var result = TestBuilder.ExecuteWorkItem(work!);
+            var work = TestBuilder.CreateWorkItem(suite);
+            var result = TestBuilder.ExecuteWorkItem(work);
 
             var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderBefore));
             var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderAfter));
@@ -253,8 +256,8 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyOrderReferrer), typeof(FixtureDependencyOrderTarget));
 
-            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            var result = TestBuilder.ExecuteWorkItem(work!);
+            var work = TestBuilder.CreateWorkItem(suite);
+            var result = TestBuilder.ExecuteWorkItem(work);
 
             var referrerResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderReferrer));
             var targetResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderTarget));
@@ -274,8 +277,8 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyAfter), typeof(FixtureDependencyBefore), typeof(FixtureDependencyOrderTarget));
 
-            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
-            var result = TestBuilder.ExecuteWorkItem(work!);
+            var work = TestBuilder.CreateWorkItem(suite);
+            var result = TestBuilder.ExecuteWorkItem(work);
 
             var dependencyAfter = result.Children.Single(x => x.Name == nameof(FixtureDependencyAfter));
             var dependencyBefore = result.Children.Single(x => x.Name == nameof(FixtureDependencyBefore));

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -24,18 +24,18 @@ namespace NUnit.Framework.Tests.Attributes
         {
             var usage = (AttributeUsageAttribute)Attribute.GetCustomAttribute(typeof(DependsOnAttribute), typeof(AttributeUsageAttribute))!;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(usage.ValidOn, Is.EqualTo(AttributeTargets.Class));
                 Assert.That(usage.AllowMultiple, Is.False);
                 Assert.That(usage.Inherited, Is.False);
-            });
+            }
         }
 
         [Test]
         public void AppliesDependencyTypeToFixtureProperties()
         {
-            var fixture = TestBuilder.MakeFixture(typeof(FixtureDependencyAfter));
+            var fixture = TestBuilder.MakeFixture<FixtureDependencyAfter>();
 
             Assert.That(fixture.Properties.Get(PropertyNames.DependsOn), Is.EqualTo(typeof(FixtureDependencyBefore)));
         }
@@ -48,14 +48,14 @@ namespace NUnit.Framework.Tests.Attributes
             var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
             Assert.That(work, Is.Not.Null);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(work!.Children, Has.Count.EqualTo(2));
                 Assert.That(work.Children[0].Test.Name, Is.EqualTo(nameof(FixtureDependencyBefore)));
                 Assert.That(work.Children[1].Test.Name, Is.EqualTo(nameof(FixtureDependencyAfter)));
                 Assert.That(work.Children[0].ParallelScope, Is.EqualTo(ParallelScope.Default));
                 Assert.That(work.Children[1].ParallelScope, Is.EqualTo(ParallelScope.Default));
-            });
+            }
         }
 
         [Test]
@@ -74,13 +74,13 @@ namespace NUnit.Framework.Tests.Attributes
             var beforeTearDownIndex = FixtureDependencyEvents.Events.IndexOf(nameof(FixtureDependencyBeforeFailing) + ".OneTimeTearDown");
             var afterSetUpIndex = FixtureDependencyEvents.Events.IndexOf(nameof(FixtureDependencyAfterFailing) + ".OneTimeSetUp");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(beforeResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
                 Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
                 Assert.That(beforeTearDownIndex, Is.GreaterThanOrEqualTo(0));
                 Assert.That(afterSetUpIndex, Is.GreaterThan(beforeTearDownIndex));
-            });
+            }
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace NUnit.Framework.Tests.Attributes
             var cycleAResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyCycleA));
             var cycleBResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyCycleB));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(cycleAResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
                 Assert.That(cycleBResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
@@ -105,7 +105,7 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(cycleAResult.Message, Does.Contain("Circular DependsOn dependency detected."));
                 Assert.That(cycleBResult.Message, Does.Contain("Circular DependsOn dependency detected."));
                 Assert.That(FixtureDependencyEvents.Events, Is.Empty);
-            });
+            }
         }
 
         [Test]
@@ -121,13 +121,13 @@ namespace NUnit.Framework.Tests.Attributes
             var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderBefore));
             var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderAfter));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(beforeResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
                 Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
                 Assert.That(afterResult.ResultState.Label, Is.EqualTo("Invalid"));
                 Assert.That(afterResult.Message, Does.Contain("Fixture may not participate in both DependsOn and Order chains."));
-            });
+            }
         }
 
         [Test]
@@ -143,13 +143,13 @@ namespace NUnit.Framework.Tests.Attributes
             var referrerResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderReferrer));
             var targetResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyOrderTarget));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(referrerResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
                 Assert.That(targetResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
                 Assert.That(targetResult.ResultState.Label, Is.EqualTo("Invalid"));
                 Assert.That(targetResult.Message, Does.Contain("Fixture may not participate in both DependsOn and Order chains."));
-            });
+            }
         }
 
         [Test]
@@ -176,7 +176,7 @@ namespace NUnit.Framework.Tests.Attributes
             var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyParallelAfter));
             var independentResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyParallelIndependent));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(beforeResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
                 Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
@@ -187,7 +187,7 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(independentResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
                 Assert.That(FixtureDependencyEvents.Events, Does.Not.Contain(nameof(FixtureDependencyParallelBeforeSlow) + ".OneTimeSetUp"));
                 Assert.That(FixtureDependencyEvents.Events, Does.Not.Contain(nameof(FixtureDependencyParallelAfter) + ".OneTimeSetUp"));
-            });
+            }
         }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -10,7 +10,7 @@ using NUnit.TestData;
 
 namespace NUnit.Framework.Tests.Attributes
 {
-    [TestFixture]
+    [TestFixture, NonParallelizable]
     public class DependsOnAttributeTests
     {
         [SetUp]
@@ -59,7 +59,7 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         [Test]
-        public void DependentFixtureRunsAfterDependencyCompletesEvenIfDependencyFails()
+        public void DependentFixtureIsSkippedIfDependencyFails()
         {
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyAfterFailing), typeof(FixtureDependencyBeforeFailing));
 
@@ -77,9 +77,10 @@ namespace NUnit.Framework.Tests.Attributes
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(beforeResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
-                Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Skipped));
                 Assert.That(beforeTearDownIndex, Is.GreaterThanOrEqualTo(0));
-                Assert.That(afterSetUpIndex, Is.GreaterThan(beforeTearDownIndex));
+                // The dependent fixture should not have run at all, so its SetUp should not be in the events
+                Assert.That(afterSetUpIndex, Is.EqualTo(-1));
             }
         }
 
@@ -145,7 +146,8 @@ namespace NUnit.Framework.Tests.Attributes
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(referrerResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(referrerResult.ResultState.Status, Is.EqualTo(TestStatus.Skipped));
+                Assert.That(referrerResult.Message, Does.Contain("did not pass"));
                 Assert.That(targetResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
                 Assert.That(targetResult.ResultState.Label, Is.EqualTo("Invalid"));
                 Assert.That(targetResult.Message, Does.Contain("Fixture may not participate in both DependsOn and Order chains."));

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.Linq;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Execution;
+using NUnit.Framework.Tests.TestUtilities;
+using NUnit.TestData;
+
+namespace NUnit.Framework.Tests.Attributes
+{
+    [TestFixture]
+    public class DependsOnAttributeTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            FixtureDependencyEvents.Reset();
+        }
+
+        [Test]
+        public void AttributeUsageIsClassLevelSingleUse()
+        {
+            var usage = (AttributeUsageAttribute)Attribute.GetCustomAttribute(typeof(DependsOnAttribute), typeof(AttributeUsageAttribute))!;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(usage.ValidOn, Is.EqualTo(AttributeTargets.Class));
+                Assert.That(usage.AllowMultiple, Is.False);
+                Assert.That(usage.Inherited, Is.False);
+            });
+        }
+
+        [Test]
+        public void AppliesDependencyTypeToFixtureProperties()
+        {
+            var fixture = TestBuilder.MakeFixture(typeof(FixtureDependencyAfter));
+
+            Assert.That(fixture.Properties.Get(PropertyNames.DependsOn), Is.EqualTo(typeof(FixtureDependencyBefore)));
+        }
+
+        [Test]
+        public void DependencyFixturesAreOrderedAndMarkedNonParallel()
+        {
+            var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyAfter), typeof(FixtureDependencyBefore));
+
+            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            Assert.That(work, Is.Not.Null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(work!.Children, Has.Count.EqualTo(2));
+                Assert.That(work.Children[0].Test.Name, Is.EqualTo(nameof(FixtureDependencyBefore)));
+                Assert.That(work.Children[1].Test.Name, Is.EqualTo(nameof(FixtureDependencyAfter)));
+                Assert.That(work.Children[0].ParallelScope, Is.EqualTo(ParallelScope.None));
+                Assert.That(work.Children[1].ParallelScope, Is.EqualTo(ParallelScope.None));
+            });
+        }
+
+        [Test]
+        public void DependentFixtureRunsAfterDependencyCompletesEvenIfDependencyFails()
+        {
+            var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyAfterFailing), typeof(FixtureDependencyBeforeFailing));
+
+            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            Assert.That(work, Is.Not.Null);
+
+            var result = TestBuilder.ExecuteWorkItem(work!);
+
+            var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyBeforeFailing));
+            var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyAfterFailing));
+
+            var beforeTearDownIndex = FixtureDependencyEvents.Events.IndexOf(nameof(FixtureDependencyBeforeFailing) + ".OneTimeTearDown");
+            var afterSetUpIndex = FixtureDependencyEvents.Events.IndexOf(nameof(FixtureDependencyAfterFailing) + ".OneTimeSetUp");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(beforeResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(beforeTearDownIndex, Is.GreaterThanOrEqualTo(0));
+                Assert.That(afterSetUpIndex, Is.GreaterThan(beforeTearDownIndex));
+            });
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -85,6 +85,26 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(afterSetUpIndex, Is.EqualTo(-1));
             }
         }
+        [Test]
+        public void DependentFixtureIsNotRunnableIfDependencyAbsent()
+        {
+            var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyAfter));
+
+            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            var result = TestBuilder.ExecuteWorkItem(work!);
+
+            var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyAfter));
+            var afterSetUpRan = FixtureDependencyEvents.Events.Contains(nameof(FixtureDependencyAfter) + ".OneTimeSetUp");
+            var expectedMsg = $"Test dependency {typeof(FixtureDependencyBefore)} can not be found. Please verify it was configured correctly and was not filtered out.";
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(afterResult.ResultState.Label, Is.EqualTo("Invalid"));
+                Assert.That(afterResult.Message, Does.Contain(expectedMsg));
+                Assert.That(afterSetUpRan, Is.False);
+            }
+        }
 
         [Test]
         public void DependentFixtureRunsWhenDependencyFailsAndRequiresSuccessIsFalse()

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -73,16 +73,13 @@ namespace NUnit.Framework.Tests.Attributes
             var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyBeforeFailing));
             var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyAfterFailing));
 
-            var beforeTearDownIndex = FixtureDependencyEvents.Events.IndexOf(nameof(FixtureDependencyBeforeFailing) + ".OneTimeTearDown");
-            var afterSetUpIndex = FixtureDependencyEvents.Events.IndexOf(nameof(FixtureDependencyAfterFailing) + ".OneTimeSetUp");
-
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(beforeResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
                 Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Skipped));
-                Assert.That(beforeTearDownIndex, Is.GreaterThanOrEqualTo(0));
-                // The dependent fixture should not have run at all, so its SetUp should not be in the events
-                Assert.That(afterSetUpIndex, Is.EqualTo(-1));
+
+                Assert.That(FixtureDependencyEvents.Events, Does.Contain(beforeResult.Name + ".OneTimeTearDown"));
+                Assert.That(FixtureDependencyEvents.Events, Does.Not.Contain(afterResult.Name + ".OneTimeSetUp"));
             }
         }
         [Test]
@@ -94,7 +91,6 @@ namespace NUnit.Framework.Tests.Attributes
             var result = TestBuilder.ExecuteWorkItem(work!);
 
             var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyAfter));
-            var afterSetUpRan = FixtureDependencyEvents.Events.Contains(nameof(FixtureDependencyAfter) + ".OneTimeSetUp");
             var expectedMsg = $"Test dependency {typeof(FixtureDependencyBefore)} can not be found. Please verify it was configured correctly and was not filtered out.";
 
             using (Assert.EnterMultipleScope())
@@ -102,7 +98,8 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
                 Assert.That(afterResult.ResultState.Label, Is.EqualTo("Invalid"));
                 Assert.That(afterResult.Message, Does.Contain(expectedMsg));
-                Assert.That(afterSetUpRan, Is.False);
+
+                Assert.That(FixtureDependencyEvents.Events, Does.Not.Contain(afterResult.Name + ".OneTimeSetUp"));
             }
         }
 
@@ -117,15 +114,13 @@ namespace NUnit.Framework.Tests.Attributes
             var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyBeforeFailing));
             var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyAfterFailingAllowed));
 
-            var beforeTearDownIndex = FixtureDependencyEvents.Events.IndexOf(nameof(FixtureDependencyBeforeFailing) + ".OneTimeTearDown");
-            var afterSetUpIndex = FixtureDependencyEvents.Events.IndexOf(nameof(FixtureDependencyAfterFailingAllowed) + ".OneTimeSetUp");
-
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(beforeResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
                 Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-                Assert.That(beforeTearDownIndex, Is.GreaterThanOrEqualTo(0));
-                Assert.That(afterSetUpIndex, Is.GreaterThan(beforeTearDownIndex));
+
+                Assert.That(FixtureDependencyEvents.Events, Does.Contain(beforeResult.Name + ".OneTimeTearDown"));
+                Assert.That(FixtureDependencyEvents.Events, Does.Contain(afterResult.Name + ".OneTimeSetUp"));
             }
         }
 
@@ -305,8 +300,9 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(beforeResult.Message, Does.Contain("Fixture dependency chains may not include fixtures configured for parallel execution."));
                 Assert.That(afterResult.Message, Does.Contain("Fixture dependency chains may not include fixtures configured for parallel execution."));
                 Assert.That(independentResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
-                Assert.That(FixtureDependencyEvents.Events, Does.Not.Contain(nameof(FixtureDependencyParallelBeforeSlow) + ".OneTimeSetUp"));
-                Assert.That(FixtureDependencyEvents.Events, Does.Not.Contain(nameof(FixtureDependencyParallelAfter) + ".OneTimeSetUp"));
+
+                Assert.That(FixtureDependencyEvents.Events, Does.Not.Contain(beforeResult.Name + ".OneTimeSetUp"));
+                Assert.That(FixtureDependencyEvents.Events, Does.Not.Contain(afterResult.Name + ".OneTimeSetUp"));
             }
         }
     }

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -53,8 +53,8 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(work!.Children, Has.Count.EqualTo(2));
                 Assert.That(work.Children[0].Test.Name, Is.EqualTo(nameof(FixtureDependencyBefore)));
                 Assert.That(work.Children[1].Test.Name, Is.EqualTo(nameof(FixtureDependencyAfter)));
-                Assert.That(work.Children[0].ParallelScope, Is.EqualTo(ParallelScope.None));
-                Assert.That(work.Children[1].ParallelScope, Is.EqualTo(ParallelScope.None));
+                Assert.That(work.Children[0].ParallelScope, Is.EqualTo(ParallelScope.Default));
+                Assert.That(work.Children[1].ParallelScope, Is.EqualTo(ParallelScope.Default));
             });
         }
 
@@ -149,6 +149,44 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(targetResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
                 Assert.That(targetResult.ResultState.Label, Is.EqualTo("Invalid"));
                 Assert.That(targetResult.Message, Does.Contain("Fixture may not participate in both DependsOn and Order chains."));
+            });
+        }
+
+        [Test]
+        public void ParallelConfiguredFixtureInvalidatesDependencyChain()
+        {
+            var suite = new TestSuite("dummy")
+                .Containing(typeof(FixtureDependencyParallelAfter), typeof(FixtureDependencyParallelBeforeSlow), typeof(FixtureDependencyParallelIndependent));
+            suite.Properties.Set(PropertyNames.ParallelScope, ParallelScope.Fixtures);
+
+            var dispatcher = new ParallelWorkItemDispatcher(4);
+            var context = new TestExecutionContext
+            {
+                Dispatcher = dispatcher
+            };
+
+            var work = TestBuilder.CreateWorkItem(suite, context) as CompositeWorkItem;
+            Assert.That(work, Is.Not.Null);
+
+            dispatcher.Start(work!);
+            work!.WaitForCompletion();
+
+            var result = work.Result;
+            var beforeResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyParallelBeforeSlow));
+            var afterResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyParallelAfter));
+            var independentResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyParallelIndependent));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(beforeResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(beforeResult.ResultState.Label, Is.EqualTo("Invalid"));
+                Assert.That(afterResult.ResultState.Label, Is.EqualTo("Invalid"));
+                Assert.That(beforeResult.Message, Does.Contain("Fixture dependency chains may not include fixtures configured for parallel execution."));
+                Assert.That(afterResult.Message, Does.Contain("Fixture dependency chains may not include fixtures configured for parallel execution."));
+                Assert.That(independentResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(FixtureDependencyEvents.Events, Does.Not.Contain(nameof(FixtureDependencyParallelBeforeSlow) + ".OneTimeSetUp"));
+                Assert.That(FixtureDependencyEvents.Events, Does.Not.Contain(nameof(FixtureDependencyParallelAfter) + ".OneTimeSetUp"));
             });
         }
     }

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -82,5 +82,30 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(afterSetUpIndex, Is.GreaterThan(beforeTearDownIndex));
             });
         }
+
+        [Test]
+        public void CycleMarksAllFixturesAsNotRunnable()
+        {
+            var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyCycleA), typeof(FixtureDependencyCycleB));
+
+            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            Assert.That(work, Is.Not.Null);
+
+            var result = TestBuilder.ExecuteWorkItem(work!);
+
+            var cycleAResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyCycleA));
+            var cycleBResult = result.Children.Single(x => x.Name == nameof(FixtureDependencyCycleB));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(cycleAResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(cycleBResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(cycleAResult.ResultState.Label, Is.EqualTo("Invalid"));
+                Assert.That(cycleBResult.ResultState.Label, Is.EqualTo("Invalid"));
+                Assert.That(cycleAResult.Message, Does.Contain("Circular DependsOn dependency detected."));
+                Assert.That(cycleBResult.Message, Does.Contain("Circular DependsOn dependency detected."));
+                Assert.That(FixtureDependencyEvents.Events, Is.Empty);
+            });
+        }
     }
 }

--- a/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnAttributeTests.cs
@@ -139,6 +139,27 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         [Test]
+        public void SelfReferentialMarksFixtureAsNotRunnable()
+        {
+            var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencySelfReferential));
+
+            var work = TestBuilder.CreateWorkItem(suite) as CompositeWorkItem;
+            Assert.That(work, Is.Not.Null);
+
+            var result = TestBuilder.ExecuteWorkItem(work!);
+
+            var selfReferentialResult = result.Children.Single(x => x.Name == nameof(FixtureDependencySelfReferential));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(selfReferentialResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
+                Assert.That(selfReferentialResult.ResultState.Label, Is.EqualTo("Invalid"));
+                Assert.That(selfReferentialResult.Message, Does.Contain("Circular DependsOn dependency detected."));
+                Assert.That(FixtureDependencyEvents.Events, Is.Empty);
+            }
+        }
+
+        [Test]
         public void FixtureUsingDependsOnAndOrderIsMarkedInvalid()
         {
             var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyOrderBefore), typeof(FixtureDependencyOrderAfter));


### PR DESCRIPTION
Contributes to #51 

I'm putting this up as a working MVP for feedback from @nunit/framework-team for fixture-level test dependencies.

It carries the following limitations for simplicity:
- Fixture -> Fixture dependency tracking
  - Method -> Method will be future. This would also require ensuring the attribute is used "correctly" in the correct context (ex: fixture-level dependencies specified at class-level only, etc). That would likely be both framework-level (reactive) checks and analyzer-level (proactive) checks.
  - The signature for method->method will be `DependsOn(string testName)` to clearly separate fixture-level and method-level dependencies within API. We will support dependencies on test methods but not parameterized tests, which are aggregated _under_ a test method
- Not used with `Order`
  - These are two distinct ordering schemes which would be hard to reconcile.
- Not used with `Parallelizable`
  - For now, but this could be adjusted in the future. I suspect suites currently setup to require this sort of deterministic ordering are also unlikely to use nondeterministic fixture-level parallelism.
- The dependent suite is run _after_ the dependency completes
- The dependent suite is run regardless of if the dependency completed successfully or not
  - UPDATE: It now requires dependant to pass, which can be overridden using a property on `DependsOnAttribute`

Incompatible use with `Order` or `Parallelizable` will result in the dependency chain becoming `NotRunnable`. 

DependsOn vs Order Comparison
- Ability to only run dependant test only if dependency passed. This helps ensure any reliant data setup has completed successfully. Can be overridden
- Clearer link between dependencies makes it easier to maintain dependency chains over time
- Clearer link between dependencies allows for clearer error reporting when they are misconfigured or filtered out.
  - Accidental filtering may happen through regular filters or using test partitioning
  - Misconfiguration may happen if mistyping a dependency or removing a dependency through refactoring
- More internal flexibility of how we run these since we can see more information about the intended dependency. We _do_ have to run all `Order` tests first, but we likely don't _have_ to always run all `DependsOn` tests first

> [!NOTE]  
> I leaned on AI for this one in the first three commits. Each step of the changes were reviewed before moving on