### PR TITLE
Eliminate force argument for StopRun under .NET Core

### DIFF
--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -246,6 +246,7 @@ namespace NUnit.Framework.Api
             Runner.RunAsync(new TestProgressReporter(handler), TestFilter.FromXml(filter));
         }
 
+#if THREAD_ABORT
         /// <summary>
         /// Stops the test run
         /// </summary>
@@ -254,6 +255,15 @@ namespace NUnit.Framework.Api
         {
             Runner.StopRun(force);
         }
+#else
+        /// <summary>
+        /// Stops the test run
+        /// </summary>
+        public void StopRun()
+        {
+            Runner.StopRun();
+        }
+#endif
 
         /// <summary>
         /// Counts the number of test cases in the loaded TestSuite
@@ -265,7 +275,7 @@ namespace NUnit.Framework.Api
             return Runner.CountTestCases(TestFilter.FromXml(filter));
         }
 
-        #endregion
+#endregion
 
         #region Private Action Methods Used by Nested Classes
 
@@ -294,10 +304,11 @@ namespace NUnit.Framework.Api
             Runner.RunAsync(new TestProgressReporter(handler), TestFilter.FromXml(filter));
         }
 
-        private void StopRun(ICallbackEventHandler handler, bool force)
-        {
-            StopRun(force);
-        }
+#if THREAD_ABORT
+        private void StopRun(ICallbackEventHandler handler, bool force) => StopRun(force);
+#else
+        private void StopRun(ICallbackEventHandler handler) => StopRun();
+#endif
 
         private void CountTests(ICallbackEventHandler handler, string? filter)
         {
@@ -408,7 +419,7 @@ namespace NUnit.Framework.Api
             }
         }
 
-        #endregion
+#endregion
 
         #region Nested Action Classes
 
@@ -536,6 +547,7 @@ namespace NUnit.Framework.Api
         /// </summary>
         public class StopRunAction : FrameworkControllerAction
         {
+#if THREAD_ABORT
             /// <summary>
             /// Construct a StopRunAction and stop any ongoing run. If no
             /// run is in process, no error is raised.
@@ -548,6 +560,20 @@ namespace NUnit.Framework.Api
             {
                 controller.StopRun((ICallbackEventHandler)handler, force);
             }
+#else
+            /// <summary>
+            /// Construct a StopRunAction and stop any ongoing run. If no
+            /// run is in process, no error is raised.
+            /// </summary>
+            /// <param name="controller">The FrameworkController for which a run is to be stopped.</param>
+            /// <param name="force">True the stop should be forced, false for a cooperative stop.</param>
+            /// <param name="handler">>A callback handler used to report results</param>
+            /// <remarks>A forced stop will cause threads and processes to be killed as needed.</remarks>
+            public StopRunAction(FrameworkController controller, bool force, object handler)
+            {
+                controller.StopRun((ICallbackEventHandler)handler);
+            }
+#endif
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Api/ITestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/ITestAssemblyRunner.cs
@@ -100,11 +100,18 @@ namespace NUnit.Framework.Api
         /// <returns>True if the run completed, otherwise false</returns>
         bool WaitForCompletion(int timeout);
 
+#if THREAD_ABORT
         /// <summary>
         /// Signal any test run that is in process to stop. Return without error if no test is running.
         /// </summary>
         /// <param name="force">If true, kill any test-running threads</param>
         void StopRun(bool force);
+#else
+        /// <summary>
+        /// Signal any test run that is in process to stop. Return without error if no test is running.
+        /// </summary>
+        void StopRun();
+#endif
 
         #endregion
     }

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -319,6 +319,7 @@ namespace NUnit.Framework.Api
             return _runComplete.Wait(timeout);
         }
 
+#if THREAD_ABORT
         /// <summary>
         /// Signal any test run that is in process to stop. Return without error if no test is running.
         /// </summary>
@@ -334,6 +335,20 @@ namespace NUnit.Framework.Api
                 Context.Dispatcher.CancelRun(force);
             }
         }
+#else
+        /// <summary>
+        /// Signal any test run that is in process to stop. Return without error if no test is running.
+        /// </summary>
+        public void StopRun()
+        {
+            if (IsTestRunning && Context is not null)
+            {
+                Context.ExecutionStatus = TestExecutionStatus.StopRequested;
+
+                Context.Dispatcher.CancelRun(false);
+            }
+        }
+#endif
 
         #endregion
 


### PR DESCRIPTION
Fixes #5367 

Hope I got the framework team process right... I'm used to seeing the branch itself succeed in a CI run before creating a PR but that doesn't seem to be how the workflow is set up.

This PR fixes #5367 using a simplified approach... only the public APIs and underlying implementations are affected, i.e. `ITestAssemblyRunner`, `NUnitTestAssemblyRunner` and `FrameworkController`.

I considered two alternative approaches but didn't take them at this time...

1. Going deeper, for example into the dispatcher, which continues to support abort but relies on not getting any calls. This seems unnecessary.

2. More formally identifying the two different public interfaces into the framework... one originally used for .NET Framework and the newer API introduced by @rprouse for use with .NET Core. Within the engine I have, in fact formalized these, calling them the 2009 and 2018 APIs. In fact the V4 engine uses the more efficient 2018 API for .NET Framework IFF the nunit version is 3.3 or higher. This seems somewhat desirable for clarity but is more work than is needed at this time. At any point where you no longer care about running tests from 3.0-3.2 that entire API could be dropped.

I'm hoping what I've done will turn out to be the "goldilocks" approach. ;-)