### PR TITLE
Get TestFixtureAttribute from outer class if not explicitly specified on inner class

### DIFF
--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -70,11 +70,11 @@ namespace NUnit.Framework.Internal.Builders
             {
                 IFixtureBuilder[] builders = GetFixtureBuilderAttributes(typeInfo);
 
-                if (builders.Length == 0 && typeInfo.IsGenericTypeDefinition)
+                if (HasNoneOrSingleTestFixtureAttributeWithNoArguments(builders) && typeInfo.IsGenericTypeDefinition)
                 {
                     // If no fixture builder attributes are found on the type, we look for them on the declaring type, if any.
                     Type? declaringType = typeInfo.Type.DeclaringType;
-                    while (builders.Length == 0 && declaringType is not null)
+                    while (HasNoneOrSingleTestFixtureAttributeWithNoArguments(builders) && declaringType is not null)
                     {
                         builders = GetFixtureBuilderAttributes(new TypeWrapper(declaringType));
                         declaringType = declaringType.DeclaringType;
@@ -125,6 +125,13 @@ namespace NUnit.Framework.Internal.Builders
                 suite.Add(fixture);
 
             return suite;
+        }
+
+        private static bool HasNoneOrSingleTestFixtureAttributeWithNoArguments(IFixtureBuilder[] builders)
+        {
+            return builders.Length == 0 ||
+                   builders.Length == 1 && builders[0] is TestFixtureAttribute testFixture &&
+                                           testFixture.Arguments.Length == 0 && testFixture.TypeArgs.Length == 0;
         }
 
         /// <summary>

--- a/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Builders/DefaultSuiteBuilder.cs
@@ -39,7 +39,10 @@ namespace NUnit.Framework.Internal.Builders
             // TODO: What about automatic fixtures? Should there
             // be some kind of error shown?
             if (typeInfo.IsGenericTypeDefinition)
-                return false;
+            {
+                return typeInfo.Type.DeclaringType is not null &&
+                       typeInfo.Type.DeclaringType.HasAttribute<IFixtureBuilder>(true);
+            }
 
             return typeInfo.HasMethodWithAttribute(typeof(IImplyFixture));
         }
@@ -66,6 +69,17 @@ namespace NUnit.Framework.Internal.Builders
             try
             {
                 IFixtureBuilder[] builders = GetFixtureBuilderAttributes(typeInfo);
+
+                if (builders.Length == 0 && typeInfo.IsGenericTypeDefinition)
+                {
+                    // If no fixture builder attributes are found on the type, we look for them on the declaring type, if any.
+                    Type? declaringType = typeInfo.Type.DeclaringType;
+                    while (builders.Length == 0 && declaringType is not null)
+                    {
+                        builders = GetFixtureBuilderAttributes(new TypeWrapper(declaringType));
+                        declaringType = declaringType.DeclaringType;
+                    }
+                }
 
                 foreach (var builder in builders)
                 {

--- a/src/NUnitFramework/testdata/ParameterizedTestFixture.cs
+++ b/src/NUnitFramework/testdata/ParameterizedTestFixture.cs
@@ -73,10 +73,20 @@ namespace NUnit.TestData
     }
 
     [TestFixture(typeof(string))]
-    [TestFixture(typeof(int))]
+    [TestFixture(TypeArgs = [typeof(int)])]
     public static class GenericClassWith<T>
     {
-        public class NestedClass
+        public class NestedClassImplicitTextFixtureAttribute
+        {
+            [Test]
+            public void Test()
+            {
+                Assert.That(typeof(T).IsClass, Is.True);
+            }
+        }
+
+        [TestFixture]
+        public class NestedClassExplicitTestFixtureAttribute
         {
             [Test]
             public void Test()

--- a/src/NUnitFramework/testdata/ParameterizedTestFixture.cs
+++ b/src/NUnitFramework/testdata/ParameterizedTestFixture.cs
@@ -71,4 +71,18 @@ namespace NUnit.TestData
         {
         }
     }
+
+    [TestFixture(typeof(string))]
+    [TestFixture(typeof(int))]
+    public static class GenericClassWith<T>
+    {
+        public class NestedClass
+        {
+            [Test]
+            public void Test()
+            {
+                Assert.That(typeof(T).IsClass, Is.True);
+            }
+        }
+    }
 }

--- a/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
@@ -244,6 +244,44 @@ namespace NUnit.Framework.Tests.Attributes
             Assert.That(fixture.Properties.Get(PropertyNames.SkipReason), Is.EqualTo(
                 "Fixture type contains generic parameters. You must either provide Type arguments or specify constructor arguments that allow NUnit to deduce the Type arguments."));
         }
+
+        [Test]
+        public void GenericTestWithNestedClassTests()
+        {
+            var suiteBuilder = new Framework.Internal.Builders.DefaultSuiteBuilder();
+            var typeInfo = new TypeWrapper(typeof(GenericClassWith<>.NestedClass));
+            Assert.That(suiteBuilder.CanBuildFrom(typeInfo), Is.True,
+                "Nested generic fixtures should be discoverable when the declaring type provides TestFixtureAttribute(s).");
+            TestSuite parameterizedFixture = suiteBuilder.BuildFrom(typeInfo);
+
+            Assert.That(parameterizedFixture.Tests, Has.Count.EqualTo(2));
+            var fixturesByName = parameterizedFixture.Tests.ToDictionary(t => t.Name);
+
+            const string successfulName = "GenericClassWith<String>+NestedClass";
+            const string unsuccessfulName = "GenericClassWith<Int32>+NestedClass";
+
+            Assert.That(fixturesByName.Keys, Is.EquivalentTo([successfulName, unsuccessfulName]));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parameterizedFixture.RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(fixturesByName[successfulName].RunState, Is.EqualTo(RunState.Runnable));
+                Assert.That(fixturesByName[unsuccessfulName].RunState, Is.EqualTo(RunState.Runnable));
+            }
+
+            ITestResult fixtureResult = TestBuilder.RunTest(parameterizedFixture);
+            Assert.That(fixtureResult.ResultState, Is.EqualTo(ResultState.ChildFailure), "Overall result");
+
+            var resultsByName = fixtureResult.Children.ToDictionary(r => r.Name);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(resultsByName[successfulName].ResultState, Is.EqualTo(ResultState.Success), successfulName);
+                ITestResult testResult = resultsByName[unsuccessfulName];
+                Assert.That(testResult.ResultState, Is.EqualTo(ResultState.ChildFailure), unsuccessfulName);
+                Assert.That(testResult.Children.First().ResultState, Is.EqualTo(ResultState.Failure), "Test");
+            }
+        }
     }
 
     [TestFixture(typeof(int))]

--- a/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
+++ b/src/NUnitFramework/tests/Attributes/ParameterizedTestFixtureTests.cs
@@ -245,11 +245,12 @@ namespace NUnit.Framework.Tests.Attributes
                 "Fixture type contains generic parameters. You must either provide Type arguments or specify constructor arguments that allow NUnit to deduce the Type arguments."));
         }
 
-        [Test]
-        public void GenericTestWithNestedClassTests()
+        [TestCase(typeof(GenericClassWith<>.NestedClassImplicitTextFixtureAttribute))]
+        [TestCase(typeof(GenericClassWith<>.NestedClassExplicitTestFixtureAttribute))]
+        public void GenericClassWithNonParameterizedNestedClassTest(Type nestedClass)
         {
             var suiteBuilder = new Framework.Internal.Builders.DefaultSuiteBuilder();
-            var typeInfo = new TypeWrapper(typeof(GenericClassWith<>.NestedClass));
+            var typeInfo = new TypeWrapper(nestedClass);
             Assert.That(suiteBuilder.CanBuildFrom(typeInfo), Is.True,
                 "Nested generic fixtures should be discoverable when the declaring type provides TestFixtureAttribute(s).");
             TestSuite parameterizedFixture = suiteBuilder.BuildFrom(typeInfo);
@@ -257,8 +258,9 @@ namespace NUnit.Framework.Tests.Attributes
             Assert.That(parameterizedFixture.Tests, Has.Count.EqualTo(2));
             var fixturesByName = parameterizedFixture.Tests.ToDictionary(t => t.Name);
 
-            const string successfulName = "GenericClassWith<String>+NestedClass";
-            const string unsuccessfulName = "GenericClassWith<Int32>+NestedClass";
+            string nestedClassName = nestedClass.Name;
+            string successfulName = $"GenericClassWith<String>+{nestedClassName}";
+            string unsuccessfulName = $"GenericClassWith<Int32>+{nestedClassName}";
 
             Assert.That(fixturesByName.Keys, Is.EquivalentTo([successfulName, unsuccessfulName]));
 


### PR DESCRIPTION
Fixes #2789 

If a nested class has no `TestFixtureAttribute` look for these on the outer class.