### PR TITLE
Fixed tests for ForceStop

### DIFF
--- a/src/NUnitFramework/slow-tests/SlowTests.cs
+++ b/src/NUnitFramework/slow-tests/SlowTests.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System.Diagnostics;
+using System.Threading;
 using NUnit.Framework;
 
 namespace NUnit.Tests
@@ -8,6 +10,7 @@ namespace NUnit.Tests
     {
         public const int SINGLE_TEST_DELAY = 1000;
 
+        [Category("Interruptable")]
         public class AAA
         {
             [Test]
@@ -27,6 +30,7 @@ namespace NUnit.Tests
             }
         }
 
+        [Category("Interruptable")]
         public class BBB
         {
             [Test]
@@ -46,28 +50,62 @@ namespace NUnit.Tests
             }
         }
 
+        [Category("Hanging")]
         public class CCC
         {
             [Test]
             public void Test1()
             {
-                SlowTests.Delay();
+                SlowTests.Hanging();
             }
             [Test]
             public void Test2()
             {
-                SlowTests.Delay();
+                SlowTests.Hanging();
             }
             [Test]
             public void Test3()
             {
-                SlowTests.Delay();
+                SlowTests.Hanging();
+            }
+        }
+
+        [Category("HangingOnOwnThread")]
+        public class DDD
+        {
+            [Test]
+            [RequiresThread]
+            public void Test1()
+            {
+                SlowTests.Hanging();
+            }
+            [Test]
+            [RequiresThread]
+            public void Test2()
+            {
+                SlowTests.Hanging();
+            }
+            [Test]
+            [RequiresThread]
+            public void Test3()
+            {
+                SlowTests.Hanging();
             }
         }
 
         private static void Delay()
         {
-            System.Threading.Thread.Sleep(SINGLE_TEST_DELAY);
+            Thread.Sleep(SINGLE_TEST_DELAY);
+        }
+
+        private static void Hanging()
+        {
+            const int numberOfRepeats = 10;
+
+            for (int i = 0; i < numberOfRepeats || Debugger.IsAttached; i++)
+            {
+                Delay();
+            }
         }
     }
 }

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -605,13 +605,45 @@ namespace NUnit.Framework.Tests.Api
         ];
 
         [TestCaseSource(nameof(StopRunCases))]
-        public void StopRun_WhenTestIsRunning_StopsTest(int workers, bool force)
+        public void StopRun_WhenInterruptibleTestIsRunning_StopsTest(int workers, bool force)
+        {
+            StopRun_WhenTestIsRunning_StopsTest(workers, "Interruptable", force);
+        }
+
+        #region Issue 3682 - StopRun not cancelling non-cooperative tests
+
+        /// <summary>
+        /// Issue #3682: StopRun(true) should forcibly terminate non-cooperative tests.
+        /// </summary>
+        [Test]
+        [Explicit("This fails because only own threads are aborted, not worker threads")]
+        public void StopRun_WithForce_ShouldTerminateNonCooperativeTests_OnWorkerThread()
+        {
+            // This test verifies that on .NET Framework, forced stop actually terminates tests
+            // On .NET Core/5+, this test is skipped because Thread.Abort is not available
+            StopRun_WhenTestIsRunning_StopsTest(0, "Hanging", true);
+        }
+
+        /// <summary>
+        /// Issue #3682: StopRun(true) should forcibly terminate non-cooperative tests.
+        /// </summary>
+        [Test]
+        public void StopRun_WithForce_ShouldTerminateNonCooperativeTests_RunningOwnThread()
+        {
+            // This test verifies that on .NET Framework, forced stop actually terminates tests
+            // On .NET Core/5+, this test is skipped because Thread.Abort is not available
+            StopRun_WhenTestIsRunning_StopsTest(0, "HangingOnOwnThread", true);
+        }
+
+        #endregion
+
+        private void StopRun_WhenTestIsRunning_StopsTest(int workers, string category, bool force)
         {
             var tests = LoadSlowTests(workers);
             var count = tests.TestCaseCount;
             var stopType = force ? "forced stop" : "cooperative stop";
 
-            _runner.RunAsync(this, TestFilter.Empty);
+            _runner.RunAsync(this, new CategoryFilter(category));
 
             // Ensure that at least one test started, otherwise we aren't testing anything!
             SpinWait.SpinUntil(() => _testStartedCount > 0, CancelTestDelay);
@@ -653,40 +685,15 @@ namespace NUnit.Framework.Tests.Api
                 Assert.That(_runner.Result.PassCount, Is.LessThan(count), $"All tests passed in spite of {stopType}");
             }
         }
-#endif
 
-        #region Issue 3682 - StopRun not cancelling non-cooperative tests
-
-#if THREAD_ABORT // Can't stop run on platforms without ability to abort thread
-        /// <summary>
-        /// Issue #3682: StopRun(true) should forcibly terminate non-cooperative tests.
-        /// On .NET Framework, this works via Thread.Abort.
-        /// On .NET Core/5+, Thread.Abort is not available, so non-cooperative tests
-        /// cannot be forcibly terminated.
-        /// </summary>
-        [Test]
-        public void StopRun_WithForce_ShouldTerminateNonCooperativeTests_OnNetFramework()
+        private ITest LoadSlowTests(int workers)
         {
-            // This test verifies that on .NET Framework, forced stop actually terminates tests
-            // On .NET Core/5+, this test is skipped because Thread.Abort is not available
+            var settings = new Dictionary<string, object> { { FrameworkPackageSettings.NumberOfTestWorkers, workers } };
 
-            _ = LoadSlowTests(0); // Simple dispatcher
-            _runner.RunAsync(this, TestFilter.Empty);
-
-            // Wait for test to start
-            SpinWait.SpinUntil(() => _testStartedCount > 0, CancelTestDelay);
-
-            // Force stop
-            _runner.StopRun(force: true);
-
-            // Should complete within reasonable time on .NET Framework
-            var completed = _runner.WaitForCompletion(CancelTestDelay);
-
-            Assert.That(completed, Is.True,
-                "StopRun(true) should terminate tests on .NET Framework");
+            return _runner.Load(Path.Combine(TestContext.CurrentContext.TestDirectory, SlowTestsFile), settings);
         }
+
 #endif
-        #endregion
 
         #endregion
 
@@ -799,13 +806,6 @@ namespace NUnit.Framework.Tests.Api
 
         private static Assembly GetMockAssembly() =>
             AssemblyHelper.Load(Path.Combine(TestContext.CurrentContext.TestDirectory, MockAssemblyFile));
-
-        private ITest LoadSlowTests(int workers)
-        {
-            var settings = new Dictionary<string, object> { { FrameworkPackageSettings.NumberOfTestWorkers, workers } };
-
-            return _runner.Load(Path.Combine(TestContext.CurrentContext.TestDirectory, SlowTestsFile), settings);
-        }
 
         private void CheckParameterOutput(ITestResult result)
         {

--- a/src/NUnitFramework/tests/Attributes/RequiresThreadAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/RequiresThreadAttributeTests.cs
@@ -83,11 +83,26 @@ namespace NUnit.Framework.Tests.Attributes
         [TestFixture, RequiresThread]
         public class FixtureRequiresThread
         {
-            [Test]
-            public void RequiresThreadCanBeSetOnTestFixture()
+            private Thread _thread;
+
+            [OneTimeSetUp]
+            public void SetUp()
             {
-                // TODO: Figure out how to test this
-                // Assert.That(Environment.StackTrace, Contains.Substring("RunTestProc"));
+                _thread = Thread.CurrentThread;
+                Assert.That(Thread.CurrentThread.Name, Is.EqualTo("NUnit.Fw.WorkItemThread"));
+                Assert.That(Environment.StackTrace, Contains.Substring("WorkItem.Start"));
+            }
+
+            [Test]
+            public void RequiresThreadCanBeSetOnTestFixture1()
+            {
+                Assert.That(Thread.CurrentThread, Is.EqualTo(_thread));
+            }
+
+            [Test]
+            public void RequiresThreadCanBeSetOnTestFixture2()
+            {
+                Assert.That(Thread.CurrentThread, Is.EqualTo(_thread));
             }
         }
 


### PR DESCRIPTION
Relates to #3276 

This proof that IFF the test ARE stopped, the events are sent.
If there are no events, the test ARE not stopped.
