### PR TITLE
Remove 'force' option from Stop/Cancel.

### DIFF
--- a/src/NUnitFramework/TestBuilder.cs
+++ b/src/NUnitFramework/TestBuilder.cs
@@ -240,7 +240,7 @@ internal static class TestBuilder
             work.Execute();
         }
 
-        public void CancelRun(bool force)
+        public void CancelRun()
         {
             throw new NotImplementedException();
         }

--- a/src/NUnitFramework/framework/Api/FrameworkController.cs
+++ b/src/NUnitFramework/framework/Api/FrameworkController.cs
@@ -246,16 +246,6 @@ namespace NUnit.Framework.Api
             Runner.RunAsync(new TestProgressReporter(handler), TestFilter.FromXml(filter));
         }
 
-#if THREAD_ABORT
-        /// <summary>
-        /// Stops the test run
-        /// </summary>
-        /// <param name="force">True to force the stop, false for a cooperative stop</param>
-        public void StopRun(bool force)
-        {
-            Runner.StopRun(force);
-        }
-#else
         /// <summary>
         /// Stops the test run
         /// </summary>
@@ -263,7 +253,6 @@ namespace NUnit.Framework.Api
         {
             Runner.StopRun();
         }
-#endif
 
         /// <summary>
         /// Counts the number of test cases in the loaded TestSuite
@@ -275,7 +264,7 @@ namespace NUnit.Framework.Api
             return Runner.CountTestCases(TestFilter.FromXml(filter));
         }
 
-#endregion
+        #endregion
 
         #region Private Action Methods Used by Nested Classes
 
@@ -304,11 +293,7 @@ namespace NUnit.Framework.Api
             Runner.RunAsync(new TestProgressReporter(handler), TestFilter.FromXml(filter));
         }
 
-#if THREAD_ABORT
-        private void StopRun(ICallbackEventHandler handler, bool force) => StopRun(force);
-#else
         private void StopRun(ICallbackEventHandler handler) => StopRun();
-#endif
 
         private void CountTests(ICallbackEventHandler handler, string? filter)
         {
@@ -547,33 +532,18 @@ namespace NUnit.Framework.Api
         /// </summary>
         public class StopRunAction : FrameworkControllerAction
         {
-#if THREAD_ABORT
             /// <summary>
             /// Construct a StopRunAction and stop any ongoing run. If no
             /// run is in process, no error is raised.
             /// </summary>
             /// <param name="controller">The FrameworkController for which a run is to be stopped.</param>
-            /// <param name="force">True the stop should be forced, false for a cooperative stop.</param>
-            /// <param name="handler">>A callback handler used to report results</param>
-            /// <remarks>A forced stop will cause threads and processes to be killed as needed.</remarks>
+            /// <param name="force">Must be <see langword="false"/>, left in for compatibility with existing runners/engines.</param>
+            /// <param name="handler">A callback handler used to report results</param>
             public StopRunAction(FrameworkController controller, bool force, object handler)
             {
-                controller.StopRun((ICallbackEventHandler)handler, force);
-            }
-#else
-            /// <summary>
-            /// Construct a StopRunAction and stop any ongoing run. If no
-            /// run is in process, no error is raised.
-            /// </summary>
-            /// <param name="controller">The FrameworkController for which a run is to be stopped.</param>
-            /// <param name="force">True the stop should be forced, false for a cooperative stop.</param>
-            /// <param name="handler">>A callback handler used to report results</param>
-            /// <remarks>A forced stop will cause threads and processes to be killed as needed.</remarks>
-            public StopRunAction(FrameworkController controller, bool force, object handler)
-            {
+                Guard.ArgumentValid(force is false, "Force stop no longer supported", nameof(force));
                 controller.StopRun((ICallbackEventHandler)handler);
             }
-#endif
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Api/ITestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/ITestAssemblyRunner.cs
@@ -100,18 +100,10 @@ namespace NUnit.Framework.Api
         /// <returns>True if the run completed, otherwise false</returns>
         bool WaitForCompletion(int timeout);
 
-#if THREAD_ABORT
-        /// <summary>
-        /// Signal any test run that is in process to stop. Return without error if no test is running.
-        /// </summary>
-        /// <param name="force">If true, kill any test-running threads</param>
-        void StopRun(bool force);
-#else
         /// <summary>
         /// Signal any test run that is in process to stop. Return without error if no test is running.
         /// </summary>
         void StopRun();
-#endif
 
         #endregion
     }

--- a/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
+++ b/src/NUnitFramework/framework/Api/NUnitTestAssemblyRunner.cs
@@ -319,23 +319,6 @@ namespace NUnit.Framework.Api
             return _runComplete.Wait(timeout);
         }
 
-#if THREAD_ABORT
-        /// <summary>
-        /// Signal any test run that is in process to stop. Return without error if no test is running.
-        /// </summary>
-        /// <param name="force">If true, kill any tests that are currently running</param>
-        public void StopRun(bool force)
-        {
-            if (IsTestRunning && Context is not null)
-            {
-                Context.ExecutionStatus = force
-                    ? TestExecutionStatus.AbortRequested
-                    : TestExecutionStatus.StopRequested;
-
-                Context.Dispatcher.CancelRun(force);
-            }
-        }
-#else
         /// <summary>
         /// Signal any test run that is in process to stop. Return without error if no test is running.
         /// </summary>
@@ -345,10 +328,9 @@ namespace NUnit.Framework.Api
             {
                 Context.ExecutionStatus = TestExecutionStatus.StopRequested;
 
-                Context.Dispatcher.CancelRun(false);
+                Context.Dispatcher.CancelRun();
             }
         }
-#endif
 
         #endregion
 

--- a/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/CompositeWorkItem.cs
@@ -398,10 +398,9 @@ namespace NUnit.Framework.Internal.Execution
         private readonly object _cancelLock = new();
 
         /// <summary>
-        /// Cancel (abort or stop) a CompositeWorkItem and all of its children
+        /// Cancel a CompositeWorkItem and all of its children
         /// </summary>
-        /// <param name="force">true if the CompositeWorkItem and all of its children should be aborted, false if it should allow all currently running tests to complete</param>
-        public override void Cancel(bool force)
+        public override void Cancel()
         {
             lock (_cancelLock)
             {
@@ -409,10 +408,10 @@ namespace NUnit.Framework.Internal.Execution
                 {
                     var ctx = child.Context;
                     if (ctx is not null)
-                        ctx.ExecutionStatus = force ? TestExecutionStatus.AbortRequested : TestExecutionStatus.StopRequested;
+                        ctx.ExecutionStatus = TestExecutionStatus.StopRequested;
 
                     if (child.State == WorkItemState.Running)
-                        child.Cancel(force);
+                        child.Cancel();
                 }
             }
         }

--- a/src/NUnitFramework/framework/Internal/Execution/IWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/IWorkItemDispatcher.cs
@@ -30,7 +30,6 @@ namespace NUnit.Framework.Internal.Execution
         /// Cancel the ongoing run completely.
         /// If no run is in process, the call has no effect.
         /// </summary>
-        /// <param name="force">true if the IWorkItemDispatcher should abort all currently running WorkItems, false if it should allow all currently running WorkItems to complete</param>
-        void CancelRun(bool force);
+        void CancelRun();
     }
 }

--- a/src/NUnitFramework/framework/Internal/Execution/MainThreadWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/MainThreadWorkItemDispatcher.cs
@@ -43,9 +43,8 @@ namespace NUnit.Framework.Internal.Execution
         /// this dispatcher. Using it will throw a
         /// NotSupportedException.
         /// </summary>
-        /// <param name="force">Not used</param>
         /// <exception cref="System.NotSupportedException">If used, it will always throw this.</exception>
-        public void CancelRun(bool force)
+        public void CancelRun()
         {
             throw new NotSupportedException();
         }

--- a/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/ParallelWorkItemDispatcher.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 
 namespace NUnit.Framework.Internal.Execution
@@ -14,8 +13,6 @@ namespace NUnit.Framework.Internal.Execution
     public class ParallelWorkItemDispatcher : IWorkItemDispatcher
     {
         private static readonly Logger Log = InternalTrace.GetLogger("Dispatcher");
-
-        private const int WaitForForcedTermination = 5000;
 
         private WorkItem? _topLevelWorkItem;
         private readonly Stack<WorkItem> _savedWorkItems = new();
@@ -239,7 +236,7 @@ namespace NUnit.Framework.Internal.Execution
         /// Cancel the ongoing run completely.
         /// If no run is in process, the call has no effect.
         /// </summary>
-        public void CancelRun(bool force)
+        public void CancelRun()
         {
             if (_topLevelWorkItem is null)
             {
@@ -247,22 +244,7 @@ namespace NUnit.Framework.Internal.Execution
             }
 
             foreach (var shift in Shifts)
-                shift.Cancel(force);
-
-            if (!force)
-                return;
-
-            SpinWait.SpinUntil(() => _topLevelWorkItem.State == WorkItemState.Complete, WaitForForcedTermination);
-
-            // Notify termination of any remaining in-process suites
-            // Note this must be done in reserve order to match the stack-like behavior
-            // That way tests are marked cancelled before suites before assemblies.
-            IEnumerable<CompositeWorkItem> snapShotActiveWorkItems = SnapshotActiveWorkItems();
-            foreach (var work in snapShotActiveWorkItems.Reverse())
-            {
-                if (work.State == WorkItemState.Running)
-                    new CompositeWorkItem.OneTimeTearDownWorkItem(work).WorkItemCancelled();
-            }
+                shift.Cancel();
         }
 
         private readonly object _queueLock = new();

--- a/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItemDispatcher.cs
@@ -75,20 +75,14 @@ namespace NUnit.Framework.Internal.Execution
         private readonly object _cancelLock = new();
 
         /// <summary>
-        /// Cancel (abort or stop) the ongoing run.
+        /// Cancel the ongoing run.
         /// If no run is in process, the call has no effect.
         /// </summary>
-        /// <param name="force">true if the run should be aborted, false if it should allow its currently running test to complete</param>
-        public void CancelRun(bool force)
+        public void CancelRun()
         {
             lock (_cancelLock)
             {
-                if (_topLevelWorkItem is not null)
-                {
-                    _topLevelWorkItem.Cancel(force);
-                    if (force)
-                        _topLevelWorkItem = null;
-                }
+                _topLevelWorkItem?.Cancel();
             }
         }
         #endregion

--- a/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/TestWorker.cs
@@ -156,19 +156,13 @@ namespace NUnit.Framework.Internal.Execution
         /// <summary>
         /// Stop the thread, either immediately or after finishing the current WorkItem
         /// </summary>
-        /// <param name="force">true if the thread should be aborted, false if it should allow the currently running test to complete</param>
-        public void Cancel(bool force)
+        public void Cancel()
         {
-            if (force)
-                _running = false;
-
             lock (_cancelLock)
             {
                 if (_workerThread is not null && _currentWorkItem is not null)
                 {
-                    _currentWorkItem.Cancel(force);
-                    if (force)
-                        _currentWorkItem = null;
+                    _currentWorkItem.Cancel();
                 }
             }
         }

--- a/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItem.cs
@@ -242,50 +242,13 @@ namespace NUnit.Framework.Internal.Execution
             WorkItemComplete();
         }
 
-#if THREAD_ABORT
-        private readonly object _threadLock = new();
-        private int _nativeThreadId;
-#endif
-
         /// <summary>
-        /// Cancel (abort or stop) a WorkItem
+        /// Cancel a WorkItem
         /// </summary>
-        /// <param name="force">true if the WorkItem should be aborted, false if it should run to completion</param>
-        public virtual void Cancel(bool force)
+        public virtual void Cancel()
         {
             if (Context is not null)
-                Context.ExecutionStatus = force ? TestExecutionStatus.AbortRequested : TestExecutionStatus.StopRequested;
-
-#if THREAD_ABORT
-            if (force)
-            {
-                Thread tThread;
-                int tNativeThreadId;
-
-                lock (_threadLock)
-                {
-                    // Exit if not running on a separate thread
-                    if (_thread is null)
-                        return;
-
-                    tThread = _thread;
-                    tNativeThreadId = _nativeThreadId;
-                    _thread = null;
-                }
-
-                if (!tThread.Join(0))
-                {
-                    Log.Debug("Killing thread {0} for cancel", tThread.ManagedThreadId);
-                    ThreadUtility.Kill(tThread, tNativeThreadId);
-
-                    tThread.Join();
-
-                    ChangeResult(ResultState.Cancelled, "Cancelled by user");
-
-                    WorkItemComplete();
-                }
-            }
-#endif
+                Context.ExecutionStatus = TestExecutionStatus.StopRequested;
         }
 
         #endregion
@@ -475,10 +438,6 @@ namespace NUnit.Framework.Internal.Execution
         {
             Thread.CurrentThread.CurrentCulture = Context.CurrentCulture;
             Thread.CurrentThread.CurrentUICulture = Context.CurrentUICulture;
-#if THREAD_ABORT
-            lock (_threadLock)
-                _nativeThreadId = ThreadUtility.GetCurrentThreadNativeId();
-#endif
             RunOnCurrentThread();
         }
 

--- a/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkShift.cs
@@ -198,16 +198,12 @@ namespace NUnit.Framework.Internal.Execution
         }
 
         /// <summary>
-        /// Cancel (abort or stop) the shift without completing all work
+        /// Cancel the shift without completing all work
         /// </summary>
-        /// <param name="force">true if the WorkShift should be aborted, false if it should allow its currently running tests to complete</param>
-        public void Cancel(bool force)
+        public void Cancel()
         {
-            if (force)
-                IsActive = false;
-
             foreach (var w in Workers)
-                w.Cancel(force);
+                w.Cancel();
         }
 
         #endregion

--- a/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
+++ b/src/NUnitFramework/tests/Api/TestAssemblyRunnerTests.cs
@@ -585,39 +585,37 @@ namespace NUnit.Framework.Tests.Api
 
         #region StopRun
 
-#if THREAD_ABORT // Can't stop run on platforms without ability to abort thread
-
         // Arbitrary delay for cancellation based on the time to run each case in SlowTests
         private const int CancelTestDelay = SlowTests.SINGLE_TEST_DELAY * 2;
 
         [Test]
-        public void StopRun_WhenNoTestIsRunning_DoesNotThrow([Values] bool force)
+        public void StopRun_WhenNoTestIsRunning_DoesNotThrow()
         {
-            Assert.DoesNotThrow(() => _runner.StopRun(force));
+            Assert.DoesNotThrow(() => _runner.StopRun());
         }
 
         private static readonly TestCaseData[] StopRunCases =
         [
-            new TestCaseData(0, false).SetName("{m}(Simple dispatcher, cooperative stop)"),
-            new TestCaseData(0, true).SetName("{m}(Simple dispatcher, forced stop)"),
-            new TestCaseData(2, false).SetName("{m}(Parallel dispatcher, cooperative stop)"),
-            new TestCaseData(2, true).SetName("{m}(Parallel dispatcher, forced stop)")
+            new TestCaseData(0).SetName("{m}(Simple dispatcher, cooperative stop)"),
+            new TestCaseData(2).SetName("{m}(Parallel dispatcher, cooperative stop)"),
         ];
 
         [TestCaseSource(nameof(StopRunCases))]
-        public void StopRun_WhenTestIsRunning_StopsTest(int workers, bool force)
+        public void StopRun_WhenTestIsRunning_StopsTest(int workers)
         {
             var tests = LoadSlowTests(workers);
             var count = tests.TestCaseCount;
-            var stopType = force ? "forced stop" : "cooperative stop";
+            var stopType = "cooperative stop";
 
             _runner.RunAsync(this, TestFilter.Empty);
 
             // Ensure that at least one test started, otherwise we aren't testing anything!
             SpinWait.SpinUntil(() => _testStartedCount > 0, CancelTestDelay);
 
-            _runner.StopRun(force);
+            _runner.StopRun();
 
+            // A single test takes SINGLE_TEST_DELAY,
+            // If we wait twice as long, the test should be finished and not other should be started.
             var completionWasSignaled = _runner.WaitForCompletion(CancelTestDelay);
 
             // Write out status for debugging
@@ -653,40 +651,6 @@ namespace NUnit.Framework.Tests.Api
                 Assert.That(_runner.Result.PassCount, Is.LessThan(count), $"All tests passed in spite of {stopType}");
             }
         }
-#endif
-
-        #region Issue 3682 - StopRun not cancelling non-cooperative tests
-
-#if THREAD_ABORT // Can't stop run on platforms without ability to abort thread
-        /// <summary>
-        /// Issue #3682: StopRun(true) should forcibly terminate non-cooperative tests.
-        /// On .NET Framework, this works via Thread.Abort.
-        /// On .NET Core/5+, Thread.Abort is not available, so non-cooperative tests
-        /// cannot be forcibly terminated.
-        /// </summary>
-        [Test]
-        public void StopRun_WithForce_ShouldTerminateNonCooperativeTests_OnNetFramework()
-        {
-            // This test verifies that on .NET Framework, forced stop actually terminates tests
-            // On .NET Core/5+, this test is skipped because Thread.Abort is not available
-
-            _ = LoadSlowTests(0); // Simple dispatcher
-            _runner.RunAsync(this, TestFilter.Empty);
-
-            // Wait for test to start
-            SpinWait.SpinUntil(() => _testStartedCount > 0, CancelTestDelay);
-
-            // Force stop
-            _runner.StopRun(force: true);
-
-            // Should complete within reasonable time on .NET Framework
-            var completed = _runner.WaitForCompletion(CancelTestDelay);
-
-            Assert.That(completed, Is.True,
-                "StopRun(true) should terminate tests on .NET Framework");
-        }
-#endif
-        #endregion
 
         #endregion
 


### PR DESCRIPTION
It only worked on test using a separate thread on NET Framework.

Fixes #5373 
Fixes #3248 (variable is no longer set to null)
