### PR TITLE
Mark `OrderAttribute` deprecated

### DIFF
--- a/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
@@ -9,7 +9,7 @@ namespace NUnit.Framework
     /// <summary>
     /// Defines the order that the test will run in
     /// </summary>
-    [Obsolete("The OrderAttribute is deprecated and may be removed in a future version of NUnit. Please use DependsOnTest or DependsOnFixture instead.")]
+    [Obsolete("OrderAttribute is deprecated and may be removed in a future version of NUnit. Please use DependsOnTest or DependsOnFixture instead.")]
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class OrderAttribute : NUnitAttribute, IApplyToTest
     {

--- a/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
@@ -9,6 +9,7 @@ namespace NUnit.Framework
     /// <summary>
     /// Defines the order that the test will run in
     /// </summary>
+    [Obsolete("The OrderAttribute is deprecated and may be removed in a future version of NUnit. Please use the DependsOnAttribute instead.")]
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class OrderAttribute : NUnitAttribute, IApplyToTest
     {

--- a/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
+++ b/src/NUnitFramework/framework/Attributes/OrderAttribute.cs
@@ -9,7 +9,7 @@ namespace NUnit.Framework
     /// <summary>
     /// Defines the order that the test will run in
     /// </summary>
-    [Obsolete("The OrderAttribute is deprecated and may be removed in a future version of NUnit. Please use the DependsOnAttribute instead.")]
+    [Obsolete("The OrderAttribute is deprecated and may be removed in a future version of NUnit. Please use DependsOnTest or DependsOnFixture instead.")]
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class OrderAttribute : NUnitAttribute, IApplyToTest
     {

--- a/src/NUnitFramework/testdata/DependsOnFixtureAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/DependsOnFixtureAttributeFixture.cs
@@ -200,6 +200,7 @@ namespace NUnit.TestData
 
     [TestFixture]
     [DependsOnFixture(typeof(FixtureDependencyOrderBefore))]
+#pragma warning disable CS0618 // Type or member is obsolete
     [Order(1)]
 #pragma warning restore CS0618 // Type or member is obsolete
     public class FixtureDependencyOrderAfter

--- a/src/NUnitFramework/testdata/DependsOnFixtureAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/DependsOnFixtureAttributeFixture.cs
@@ -201,6 +201,7 @@ namespace NUnit.TestData
     [TestFixture]
     [DependsOnFixture(typeof(FixtureDependencyOrderBefore))]
     [Order(1)]
+#pragma warning restore CS0618 // Type or member is obsolete
     public class FixtureDependencyOrderAfter
     {
         [Test]
@@ -211,7 +212,9 @@ namespace NUnit.TestData
     }
 
     [TestFixture]
+#pragma warning disable CS0618 // Type or member is obsolete
     [Order(2)]
+#pragma warning restore CS0618 // Type or member is obsolete
     public class FixtureDependencyOrderTarget
     {
         [Test]

--- a/src/NUnitFramework/testdata/DependsOnTestAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/DependsOnTestAttributeFixture.cs
@@ -150,7 +150,9 @@ namespace NUnit.TestData
     public class MethodDependencyOrderTarget
     {
         [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
         [Order(1)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void Target()
         {
             FixtureDependencyEvents.Record();
@@ -178,7 +180,9 @@ namespace NUnit.TestData
 
         [Test]
         [DependsOnTest(nameof(Before))]
+#pragma warning disable CS0618 // Type or member is obsolete
         [Order(1)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void After()
         {
             FixtureDependencyEvents.Record();
@@ -205,7 +209,9 @@ namespace NUnit.TestData
         }
 
         [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
         [Order(1)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void OrderedIndependent()
         {
             FixtureDependencyEvents.Record();

--- a/src/NUnitFramework/testdata/ExecutionHooks/CombinedHookTestFixtures.cs
+++ b/src/NUnitFramework/testdata/ExecutionHooks/CombinedHookTestFixtures.cs
@@ -57,10 +57,14 @@ namespace NUnit.TestData.ExecutionHooks
 
     public class OneTestWithLoggingHooksAndOneWithoutFixture
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         [Test, ActivateTestHook, Order(1)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void TestWithHookLogging() => TestLog.LogCurrentMethod();
 
+#pragma warning disable CS0618 // Type or member is obsolete
         [Test, Order(2)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void TestWithoutHookLogging() => TestLog.LogCurrentMethod();
     }
 

--- a/src/NUnitFramework/testdata/ExecutionHooks/CombinedHookTestFixtures.cs
+++ b/src/NUnitFramework/testdata/ExecutionHooks/CombinedHookTestFixtures.cs
@@ -57,14 +57,10 @@ namespace NUnit.TestData.ExecutionHooks
 
     public class OneTestWithLoggingHooksAndOneWithoutFixture
     {
-#pragma warning disable CS0618 // Type or member is obsolete
-        [Test, ActivateTestHook, Order(1)]
-#pragma warning restore CS0618 // Type or member is obsolete
+        [Test, ActivateTestHook]
         public void TestWithHookLogging() => TestLog.LogCurrentMethod();
 
-#pragma warning disable CS0618 // Type or member is obsolete
-        [Test, Order(2)]
-#pragma warning restore CS0618 // Type or member is obsolete
+        [Test, DependsOnTest(nameof(TestWithHookLogging))]
         public void TestWithoutHookLogging() => TestLog.LogCurrentMethod();
     }
 

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -345,18 +345,13 @@ namespace NUnit.TestData.LifeCycleTests
             private int _value;
 
             [Test]
-#pragma warning disable CS0618 // Type or member is obsolete
-            [Order(0)]
-#pragma warning restore CS0618 // Type or member is obsolete
             public void Test1()
             {
                 Assert.That(_value++, Is.EqualTo(0));
             }
 
             [Test]
-#pragma warning disable CS0618 // Type or member is obsolete
-            [Order(1)]
-#pragma warning restore CS0618 // Type or member is obsolete
+            [DependsOnTest(nameof(Test1))]
             public void Test2()
             {
                 Assert.That(_value++, Is.EqualTo(1));
@@ -400,18 +395,13 @@ namespace NUnit.TestData.LifeCycleTests
         private int _value;
 
         [Test]
-#pragma warning disable CS0618 // Type or member is obsolete
-        [Order(0)]
-#pragma warning restore CS0618 // Type or member is obsolete
         public void Test1()
         {
             Assert.That(_value++, Is.EqualTo(0));
         }
 
         [Test]
-#pragma warning disable CS0618 // Type or member is obsolete
-        [Order(1)]
-#pragma warning restore CS0618 // Type or member is obsolete
+        [DependsOnTest(nameof(Test1))]
         public void Test2()
         {
             Assert.That(_value++, Is.EqualTo(1));

--- a/src/NUnitFramework/testdata/LifeCycleFixture.cs
+++ b/src/NUnitFramework/testdata/LifeCycleFixture.cs
@@ -345,14 +345,18 @@ namespace NUnit.TestData.LifeCycleTests
             private int _value;
 
             [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
             [Order(0)]
+#pragma warning restore CS0618 // Type or member is obsolete
             public void Test1()
             {
                 Assert.That(_value++, Is.EqualTo(0));
             }
 
             [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
             [Order(1)]
+#pragma warning restore CS0618 // Type or member is obsolete
             public void Test2()
             {
                 Assert.That(_value++, Is.EqualTo(1));
@@ -396,14 +400,18 @@ namespace NUnit.TestData.LifeCycleTests
         private int _value;
 
         [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
         [Order(0)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void Test1()
         {
             Assert.That(_value++, Is.EqualTo(0));
         }
 
         [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
         [Order(1)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void Test2()
         {
             Assert.That(_value++, Is.EqualTo(1));
@@ -425,11 +433,15 @@ namespace NUnit.TestData.LifeCycleTests
         }
 
         [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
         [Order(1)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void Test() => Assert.Pass();
 
         [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
         [Order(2)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void VerifyDisposed() => Assert.That(DisposeCount, Is.EqualTo(1));
     }
 
@@ -446,11 +458,15 @@ namespace NUnit.TestData.LifeCycleTests
         }
 
         [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
         [Order(1)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void Test() => Assert.Pass();
 
         [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
         [Order(2)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void VerifyDisposed() => Assert.That(DisposeCount, Is.EqualTo(1));
     }
 

--- a/src/NUnitFramework/testdata/MultipleTestFixturesOrderAttribute.cs
+++ b/src/NUnitFramework/testdata/MultipleTestFixturesOrderAttribute.cs
@@ -4,7 +4,9 @@ using NUnit.Framework;
 
 namespace NUnit.TestData.MultipleTestFixturesOrderAttribute
 {
+#pragma warning disable CS0618 // Type or member is obsolete
     [Order(2)]
+#pragma warning restore CS0618 // Type or member is obsolete
     public class NoTestFixtureAttributeOrder2
     {
         [Test]
@@ -16,7 +18,9 @@ namespace NUnit.TestData.MultipleTestFixturesOrderAttribute
 
     [TestFixture("1")]
     [TestFixture("2")]
+#pragma warning disable CS0618 // Type or member is obsolete
     [Order(1)]
+#pragma warning restore CS0618 // Type or member is obsolete
     public class MultipleTestFixtureAttributesOrder1
     {
 #pragma warning disable IDE0052 // Remove unread private members
@@ -34,7 +38,9 @@ namespace NUnit.TestData.MultipleTestFixturesOrderAttribute
         }
     }
 
+#pragma warning disable CS0618 // Type or member is obsolete
     [Order(0)]
+#pragma warning restore CS0618 // Type or member is obsolete
     public class NoTestFixtureAttributeOrder0
     {
         [Test]

--- a/src/NUnitFramework/testdata/TestCaseOrderAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/TestCaseOrderAttributeFixture.cs
@@ -5,25 +5,33 @@ using NUnit.Framework;
 namespace NUnit.TestData
 {
     [TestFixture]
+#pragma warning disable CS0618 // Type or member is obsolete
     [Order(3)]
+#pragma warning restore CS0618 // Type or member is obsolete
     public class TestCaseOrderAttributeFixture
     {
         [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
         [Order(3)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void Z_ThirdTest()
         {
             Assert.Pass("Z_ThirdTestWithSameOrderAsSecond");
         }
 
         [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
         [Order(1)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void Y_FirstTest()
         {
             Assert.Pass("Y_FirstTest");
         }
 
         [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
         [Order(2)]
+#pragma warning restore CS0618 // Type or member is obsolete
         public void Y_SecondTest()
         {
             Assert.Pass("Y_SecondTest");
@@ -43,7 +51,9 @@ namespace NUnit.TestData
     }
 
     [TestFixture]
+#pragma warning disable CS0618 // Type or member is obsolete
     [Order(1)]
+#pragma warning restore CS0618 // Type or member is obsolete
     public class AnotherTestCaseOrderAttributeFixture
     {
         [Test]
@@ -54,7 +64,9 @@ namespace NUnit.TestData
     }
 
     [TestFixture]
+#pragma warning disable CS0618 // Type or member is obsolete
     [Order(2)]
+#pragma warning restore CS0618 // Type or member is obsolete
     public class ThirdTestCaseOrderAttributeFixture
     {
         [Test]


### PR DESCRIPTION
Fixes #5378 

Note: Open to feedback on the deprecation message. The default message included a part that it "will be removed in a future version" but that felt too strong since we aren't committed to that. I changed it to "may be removed in a future version" but that part can be taken out entirely if we prefer