### PR TITLE
Add missing test case coverage for generic parameterized test methods

### DIFF
--- a/src/NUnitFramework/testdata/DependsOnTestAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/DependsOnTestAttributeFixture.cs
@@ -289,6 +289,25 @@ namespace NUnit.TestData
     }
 
     [TestFixture]
+    public class MethodDependsOnGenericParameterizedTest
+    {
+        [Test]
+        [DependsOnTest(nameof(ParameterizedTestA))]
+        public void A()
+        {
+            FixtureDependencyEvents.Record();
+            Assert.That(true, Is.True);
+        }
+
+        [Test]
+        public void ParameterizedTestA<T>([Values(1, 2)] T x)
+        {
+            FixtureDependencyEvents.Record();
+            Assert.That(true, Is.True);
+        }
+    }
+
+    [TestFixture]
     public class MethodParameterizedTestDependsOnMethod
     {
         [Test]

--- a/src/NUnitFramework/tests/Attributes/DependsOnTestAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnTestAttributeTests.cs
@@ -380,5 +380,24 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(FixtureDependencyEvents.Events, Is.EqualTo([$"{parameterizedTestA}(1)", $"{parameterizedTestA}(2)"]));
             }
         }
+
+        [Test]
+        public void RegularTestDependsOnGenericParameterizedTest()
+        {
+            var work = TestBuilder.CreateWorkItem(typeof(MethodDependsOnGenericParameterizedTest));
+            var result = TestBuilder.ExecuteWorkItem(work);
+
+            const string parameterizedTestA = nameof(MethodDependsOnGenericParameterizedTest.ParameterizedTestA);
+
+            var beforeResult = result.Children.Single(x => x.Name == parameterizedTestA);
+            var afterResult = result.Children.Single(x => x.Name == nameof(MethodDependsOnGenericParameterizedTest.A));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(beforeResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(FixtureDependencyEvents.Events, Is.EqualTo([$"{parameterizedTestA}<Int32>(1)", $"{parameterizedTestA}<Int32>(2)", "A"]));
+            }
+        }
     }
 }


### PR DESCRIPTION
Something I realized had been missed during initial sweep to cover all the cases. This already worked, but was lacking a test.
Fixes #5391