### PR TITLE
Suppress IDE0130 and IDE0290

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -172,6 +172,9 @@ dotnet_diagnostic.IDE1006.severity = warning
 # IDE0036: Order modifiers
 dotnet_diagnostic.IDE0036.severity = warning
 
+# IDE0290: Use primary constructor
+dotnet_diagnostic.IDE0290.severity = none
+
 ##################################################################################
 # CSharpIsNull Analyzers
 

--- a/CakeScripts/TestResultsParser.cs
+++ b/CakeScripts/TestResultsParser.cs
@@ -1,7 +1,5 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 

--- a/NUnit.sln.DotSettings
+++ b/NUnit.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeEditing/GenerateMemberBody/CopyXmlDocumentation/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/CalculateUnusedTypeMembers/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeModifiersOrder/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantThisQualifier/@EntryIndexedValue">SUGGESTION</s:String>

--- a/src/NUnitFramework/framework/.editorconfig
+++ b/src/NUnitFramework/framework/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+dotnet_diagnostic.IDE0130.severity = none

--- a/src/NUnitFramework/nunit.framework.legacy.tests/ClassicAssertExtensions_ComparisonTests.cs
+++ b/src/NUnitFramework/nunit.framework.legacy.tests/ClassicAssertExtensions_ComparisonTests.cs
@@ -2,7 +2,7 @@
 
 namespace NUnit.Framework.Legacy.Tests
 {
-    public class ClassicAssertExtensions_ComparisonTests
+    public class ClassicAssertExtensionsComparisonTests
     {
         [Test]
         public void Greater_Less_Comparisons()

--- a/src/NUnitFramework/nunit.framework.legacy.tests/ClassicAssertExtensions_CoreTests.cs
+++ b/src/NUnitFramework/nunit.framework.legacy.tests/ClassicAssertExtensions_CoreTests.cs
@@ -2,7 +2,7 @@
 
 namespace NUnit.Framework.Legacy.Tests
 {
-    public class ClassicAssertExtensions_CoreTests
+    public class ClassicAssertExtensionsCoreTests
     {
         [Test]
         public void Equality_and_Sameness()

--- a/src/NUnitFramework/nunit.framework.legacy.tests/ClassicAssertExtensions_NumericTests.cs
+++ b/src/NUnitFramework/nunit.framework.legacy.tests/ClassicAssertExtensions_NumericTests.cs
@@ -2,7 +2,7 @@
 
 namespace NUnit.Framework.Legacy.Tests
 {
-    public class ClassicAssertExtensions_NumericTests
+    public class ClassicAssertExtensionsNumericTests
     {
         [Test]
         public void Zero_Positive_Negative_Int()

--- a/src/NUnitFramework/nunit.framework.legacy.tests/ClassicAssertExtensions_TypeTests.cs
+++ b/src/NUnitFramework/nunit.framework.legacy.tests/ClassicAssertExtensions_TypeTests.cs
@@ -2,7 +2,7 @@
 
 namespace NUnit.Framework.Legacy.Tests
 {
-    public class ClassicAssertExtensions_TypeTests
+    public class ClassicAssertExtensionsTypeTests
     {
         private class Base
         {

--- a/src/NUnitFramework/nunit.framework.legacy.tests/CollectionAssertTest.cs
+++ b/src/NUnitFramework/nunit.framework.legacy.tests/CollectionAssertTest.cs
@@ -150,13 +150,13 @@ namespace NUnit.Framework.Legacy.Tests
             Assert.Throws<AssertionException>(() => CollectionAssert.AllItemsAreUnique(collection));
         }
 
-        private static readonly IEnumerable<int> RANGE = Enumerable.Range(0, 10_000);
+        private static readonly IEnumerable<int> Range = Enumerable.Range(0, 10_000);
         private static readonly IEnumerable[] PerformanceData =
         {
-            RANGE,
-            new List<int>(RANGE),
-            new List<double>(RANGE.Select(v => (double)v)),
-            new List<string>(RANGE.Select(v => v.ToString()))
+            Range,
+            new List<int>(Range),
+            new List<double>(Range.Select(v => (double)v)),
+            new List<string>(Range.Select(v => v.ToString()))
         };
 
         [TestCaseSource(nameof(PerformanceData))]

--- a/src/NUnitFramework/nunit.framework.legacy.tests/DirectoryAssertTests.cs
+++ b/src/NUnitFramework/nunit.framework.legacy.tests/DirectoryAssertTests.cs
@@ -11,7 +11,7 @@ namespace NUnit.Framework.Legacy.Tests
     {
         private TestDirectory _goodDir1;
         private TestDirectory _goodDir2;
-        private const string BAD_DIRECTORY = @"\I\hope\this\is\garbage";
+        private const string BadDirectory = @"\I\hope\this\is\garbage";
 
         [SetUp]
         public void SetUp()
@@ -19,7 +19,7 @@ namespace NUnit.Framework.Legacy.Tests
             _goodDir1 = new TestDirectory();
             _goodDir2 = new TestDirectory();
             Assume.That(_goodDir1.Directory, Is.Not.EqualTo(_goodDir2.Directory), "The two good directories are the same");
-            Assume.That(BAD_DIRECTORY, Does.Not.Exist, BAD_DIRECTORY + " exists");
+            Assume.That(BadDirectory, Does.Not.Exist, BadDirectory + " exists");
         }
 
         [TearDown]
@@ -123,14 +123,14 @@ namespace NUnit.Framework.Legacy.Tests
         [Test]
         public void ExistsFailsWhenDirectoryInfoDoesNotExist()
         {
-            var ex = Assert.Throws<AssertionException>(() => DirectoryAssert.Exists(new DirectoryInfo(BAD_DIRECTORY)));
+            var ex = Assert.Throws<AssertionException>(() => DirectoryAssert.Exists(new DirectoryInfo(BadDirectory)));
             Assert.That(ex?.Message, Does.Contain("  Expected: directory exists"));
         }
 
         [Test]
         public void ExistsFailsWhenStringDoesNotExist()
         {
-            var ex = Assert.Throws<AssertionException>(() => DirectoryAssert.Exists(BAD_DIRECTORY));
+            var ex = Assert.Throws<AssertionException>(() => DirectoryAssert.Exists(BadDirectory));
             Assert.That(ex?.Message, Does.Contain("  Expected: directory exists"));
         }
 
@@ -173,13 +173,13 @@ namespace NUnit.Framework.Legacy.Tests
         [Test]
         public void DoesNotExistPassesWhenDirectoryInfoDoesNotExist()
         {
-            DirectoryAssert.DoesNotExist(new DirectoryInfo(BAD_DIRECTORY));
+            DirectoryAssert.DoesNotExist(new DirectoryInfo(BadDirectory));
         }
 
         [Test]
         public void DoesNotExistPassesWhenStringDoesNotExist()
         {
-            DirectoryAssert.DoesNotExist(BAD_DIRECTORY);
+            DirectoryAssert.DoesNotExist(BadDirectory);
         }
 
         [Test]

--- a/src/NUnitFramework/nunit.framework.legacy/.editorconfig
+++ b/src/NUnitFramework/nunit.framework.legacy/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+dotnet_diagnostic.IDE0130.severity = none

--- a/src/NUnitFramework/nunitlite.tests/Common/DefaultOptionsProviderTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/Common/DefaultOptionsProviderTests.cs
@@ -4,7 +4,7 @@ using System;
 using NUnit.Common;
 using NUnit.Framework;
 
-namespace NUnit.ConsoleRunner.Tests
+namespace NUnitLite.Tests.Common
 {
     [TestFixture]
     public sealed class DefaultOptionsProviderTests

--- a/src/NUnitFramework/nunitlite.tests/Common/ExtendedTextWrapperTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/Common/ExtendedTextWrapperTests.cs
@@ -3,9 +3,10 @@
 using System;
 using System.IO;
 using System.Text;
+using NUnit.Common;
 using NUnit.Framework;
 
-namespace NUnit.Common.Tests
+namespace NUnitLite.Tests.Common
 {
     public class ExtendedTextWrapperTests
     {

--- a/src/NUnitFramework/nunitlite.tests/Common/OutputSpecificationTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/Common/OutputSpecificationTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
 using System;
+using NUnit.Common;
 using NUnit.Framework;
 
-namespace NUnit.Common.Tests
+namespace NUnitLite.Tests.Common
 {
     public class OutputSpecificationTests
     {

--- a/src/NUnitFramework/nunitlite.tests/Common/TestNameParserTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/Common/TestNameParserTests.cs
@@ -1,8 +1,9 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using NUnit.Common;
 using NUnit.Framework;
 
-namespace NUnit.Common.Tests
+namespace NUnitLite.Tests.Common
 {
     public class TestNameParserTests
     {

--- a/src/NUnitFramework/nunitlite.tests/Common/TestSelectionParserTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/Common/TestSelectionParserTests.cs
@@ -2,9 +2,10 @@
 
 using System;
 using System.Xml;
+using NUnit.Common;
 using NUnit.Framework;
 
-namespace NUnit.Common.Tests
+namespace NUnitLite.Tests.Common
 {
     public class TestSelectionParserTests
     {

--- a/src/NUnitFramework/nunitlite.tests/Common/TokenizerTests.cs
+++ b/src/NUnitFramework/nunitlite.tests/Common/TokenizerTests.cs
@@ -1,8 +1,9 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using NUnit.Common;
 using NUnit.Framework;
 
-namespace NUnit.Common.Tests
+namespace NUnitLite.Tests.Common
 {
     public class TokenizerTests
     {

--- a/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
+++ b/src/NUnitFramework/tests/Api/DefaultTestAssemblyBuilderTests.cs
@@ -12,7 +12,7 @@ namespace NUnit.Framework.Tests.Api
 {
     public class DefaultTestAssemblyBuilderTests
     {
-        private const string MOCK_ASSEMBLY_FILE = "mock-assembly.dll";
+        private const string MockAssemblyFile = "mock-assembly.dll";
 
         private string _mockAssemblyPath;
         private DefaultTestAssemblyBuilder _builder;
@@ -20,7 +20,7 @@ namespace NUnit.Framework.Tests.Api
         [SetUp]
         public void SetUp()
         {
-            _mockAssemblyPath = Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY_FILE);
+            _mockAssemblyPath = Path.Combine(TestContext.CurrentContext.TestDirectory, MockAssemblyFile);
             _builder = new DefaultTestAssemblyBuilder();
         }
 
@@ -55,7 +55,7 @@ namespace NUnit.Framework.Tests.Api
 
             Assert.That(result.IsSuite);
             Assert.That(result, Is.TypeOf<TestAssembly>());
-            Assert.That(result.Name, Is.EqualTo(MOCK_ASSEMBLY_FILE));
+            Assert.That(result.Name, Is.EqualTo(MockAssemblyFile));
             Assert.That(result.RunState, Is.EqualTo(Framework.Interfaces.RunState.Runnable), (string)result.Properties.Get(PropertyNames.SkipReason)!);
 
             return result.TestCaseCount;

--- a/src/NUnitFramework/tests/Internal/Extensions/ArgumentExtensionsTest.cs
+++ b/src/NUnitFramework/tests/Internal/Extensions/ArgumentExtensionsTest.cs
@@ -3,8 +3,10 @@
 using System;
 using System.Collections;
 using System.Threading;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Extensions;
 
-namespace NUnit.Framework.Internal.Extensions
+namespace NUnit.Framework.Tests.Internal.Extensions
 {
     [TestFixture]
     internal sealed class ArgumentExtensionsTest

--- a/src/NUnitFramework/tests/Internal/NamespaceTreeBuilderTests.cs
+++ b/src/NUnitFramework/tests/Internal/NamespaceTreeBuilderTests.cs
@@ -177,6 +177,7 @@ namespace NUnit.Framework.Tests.Internal
     }
 }
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace One
 {
     public class Fixture1


### PR DESCRIPTION

Fixes #5398 

Suppressed IDE0290, primary constructors, globally.
Suppressed IDE0130, namespace must match folders, in nunit.framework.

Doesn't touch any code in nunit.framework or nunit.framework.legacy, nor in nunitlite.
Also fixes some namespace issues in the test projects.
And a few other minor  code warnings on the way, keep the base camp clean.