### PR TITLE
Never let exception property rendering throw; skip by-ref and indexed properties

### DIFF
--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -162,7 +162,14 @@ namespace NUnit.Framework.Internal
                     var propertyEx = targetInvocationEx.InnerException ?? targetInvocationEx;
 
                     sb.AppendLine();
-                    sb.AppendFormat("  {0}: <getter threw {1}({2})", property.Name, propertyEx.GetType().Name, propertyEx.Message);
+                    sb.AppendFormat("  {0}: <getter threw {1}({2})>", property.Name, propertyEx.GetType().Name, propertyEx.GetMessageWithoutThrowing());
+                }
+                catch (Exception e)
+                {
+                    // Reflection refused the read before the getter ran (e.g. NotSupportedException for a by-ref-like
+                    // property on .NET) or the value's ToString() threw. Reporting the real failure must never abort.
+                    sb.AppendLine();
+                    sb.AppendFormat("  {0}: <unreadable: {1}({2})>", property.Name, e.GetType().Name, e.GetMessageWithoutThrowing());
                 }
             }
         }
@@ -178,6 +185,13 @@ namespace NUnit.Framework.Internal
                     property.GetMethod.GetBaseDefinition().DeclaringType == typeof(Exception))
                 {
                     // Ignore (overridden) properties from the Exception base class (Message, StackTrace) as these are mostly handled.
+                    continue;
+                }
+
+                if (property.PropertyType.IsByRef || property.GetIndexParameters().Length != 0)
+                {
+                    // By-ref returning properties cannot be read through reflection on .NET Framework (issue #5401)
+                    // and indexers cannot be read without arguments. Neither is meaningful to display.
                     continue;
                 }
 

--- a/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
+++ b/src/NUnitFramework/framework/Internal/ExceptionHelper.cs
@@ -165,6 +165,11 @@ namespace NUnit.Framework.Internal
                     sb.AppendFormat("  {0}: <getter threw {1}({2})>", property.Name, propertyEx.GetType().Name, propertyEx.GetMessageWithoutThrowing());
                 }
                 catch (Exception e)
+#if THREAD_ABORT
+                    // Never swallow a thread abort: on Mono a caught ThreadAbortException can be resurrected
+                    // at the end of a later unrelated catch block (see Reflect.InvokeMethod).
+                    when (e is not System.Threading.ThreadAbortException)
+#endif
                 {
                     // Reflection refused the read before the getter ran (e.g. NotSupportedException for a by-ref-like
                     // property on .NET) or the value's ToString() threw. Reporting the real failure must never abort.

--- a/src/NUnitFramework/tests/Internal/ExceptionHelperOutputExceptionDataTests.cs
+++ b/src/NUnitFramework/tests/Internal/ExceptionHelperOutputExceptionDataTests.cs
@@ -87,6 +87,84 @@ namespace NUnit.Framework.Tests.Internal
 
             public Dictionary<string, string>? AuxiliaryValues { get; init; }
         }
+
+        [Test]
+        public static void AppendsPropertiesToExceptionMessageSkipsByRefProperties_Issue5401()
+        {
+            // Regression: on .NET Framework PropertyInfo.GetValue throws NotSupportedException for a by-ref
+            // returning property before invoking the getter, which escaped BuildMessage and killed the worker.
+            var exception = new ByRefPropertyException("blah");
+
+            string message = ExceptionHelper.BuildMessage(exception);
+            Assert.That(message, Contains.Substring("blah"));
+            Assert.That(message, Contains.Substring("ByValue: 42"));
+            Assert.That(message, Does.Not.Contain(nameof(ByRefPropertyException.ByRefValue)));
+        }
+
+        [Test]
+        public static void AppendsPropertiesToExceptionMessageSkipsIndexers()
+        {
+            // Same escape as issue #5401: GetValue(obj) on an indexer throws TargetParameterCountException.
+            var exception = new IndexerPropertyException("blah");
+
+            string message = ExceptionHelper.BuildMessage(exception);
+            Assert.That(message, Contains.Substring("blah"));
+            Assert.That(message, Does.Not.Contain("Item"));
+        }
+
+        [Test]
+        public static void AppendsPropertiesToExceptionMessageCanDealWithByRefLikeProperties()
+        {
+            // On .NET the getter cannot be invoked through reflection (NotSupportedException); on .NET Framework
+            // System.Memory's span boxes fine. Only the TFM-independent parts of the output are asserted.
+            var exception = new ByRefLikePropertyException("blah");
+
+            string message = ExceptionHelper.BuildMessage(exception);
+            Assert.That(message, Contains.Substring("blah"));
+            Assert.That(message, Contains.Substring($"{nameof(ByRefLikePropertyException.SpanValue)}: "));
+        }
+
+        [Test]
+        public static void AppendsPropertiesToExceptionMessageClosesGetterExceptionBracket()
+        {
+            var exception = new ExceptionHelperException("blah");
+
+            string message = ExceptionHelper.BuildMessage(exception);
+            Assert.That(message, Contains.Substring($"{nameof(ExceptionHelperException.CustomProperty)}: <getter threw NullReferenceException("));
+            Assert.That(message, Contains.Substring(")>"));
+        }
+
+        private sealed class ByRefPropertyException : Exception
+        {
+            private readonly int _byRefValue = 42;
+
+            public ByRefPropertyException(string message) : base(message)
+            {
+            }
+
+            public ref readonly int ByRefValue => ref _byRefValue;
+
+            public int ByValue => _byRefValue;
+        }
+
+        private sealed class IndexerPropertyException : Exception
+        {
+            public IndexerPropertyException(string message) : base(message)
+            {
+            }
+
+            public string this[string key] => key;
+        }
+
+        private sealed class ByRefLikePropertyException : Exception
+        {
+            public ByRefLikePropertyException(string message) : base(message)
+            {
+            }
+
+            public ReadOnlySpan<char> SpanValue => "span-value".AsSpan();
+        }
+
         [Test]
         public static void IncludesNullProperties()
         {

--- a/src/NUnitFramework/tests/Internal/ExceptionHelperOutputExceptionDataTests.cs
+++ b/src/NUnitFramework/tests/Internal/ExceptionHelperOutputExceptionDataTests.cs
@@ -98,7 +98,7 @@ namespace NUnit.Framework.Tests.Internal
             string message = ExceptionHelper.BuildMessage(exception);
             Assert.That(message, Contains.Substring("blah"));
             Assert.That(message, Contains.Substring("ByValue: 42"));
-            Assert.That(message, Does.Not.Contain(nameof(ByRefPropertyException.ByRefValue)));
+            Assert.That(message, Does.Not.Contain($"{nameof(ByRefPropertyException.ByRefValue)}:"));
         }
 
         [Test]
@@ -109,14 +109,16 @@ namespace NUnit.Framework.Tests.Internal
 
             string message = ExceptionHelper.BuildMessage(exception);
             Assert.That(message, Contains.Substring("blah"));
-            Assert.That(message, Does.Not.Contain("Item"));
+            Assert.That(message, Does.Not.Contain("Item:"));
         }
 
         [Test]
         public static void AppendsPropertiesToExceptionMessageCanDealWithByRefLikeProperties()
         {
-            // On .NET the getter cannot be invoked through reflection (NotSupportedException); on .NET Framework
-            // System.Memory's span boxes fine. Only the TFM-independent parts of the output are asserted.
+            // On .NET the runtime refuses to invoke a getter returning a ref struct (NotSupportedException), so the
+            // property is rendered as "<unreadable: ...>". The .NET Framework CLR does not know IsByRefLike, so
+            // System.Memory's span is boxed there like any other struct; Mono may refuse like .NET does.
+            // Only the TFM-independent parts of the output are asserted.
             var exception = new ByRefLikePropertyException("blah");
 
             string message = ExceptionHelper.BuildMessage(exception);


### PR DESCRIPTION
Fixes #5401

### Problem

Since #5216, `ExceptionHelper.BuildMessage` renders every public instance property of a thrown exception. `PropertyInfo.GetValue` can throw *outside* the getter — so not wrapped in `TargetInvocationException` — and the existing `catch (TargetInvocationException)` let it escape `AppendExceptionProperties` → `BuildMessage` → `TestResult.RecordException` → `SimpleWorkItem.PerformWork`. The worker thread died and the run ended with `The active test run was aborted. Reason: Test host process crashed`, losing every test still queued in that process:

- `public ref readonly T Prop => ref _field;` → `NotSupportedException` on .NET Framework (the reported case; .NET Core 3.0+ dereferences instead, so only the `net462` leg died).
- Indexers → `TargetParameterCountException` on every runtime.
- `public ReadOnlySpan<char> Prop` (by-ref-like return) → `NotSupportedException` on .NET Core 3.0+.

### Fix

1. `GetPropertiesToDisplay` skips by-ref returning properties and indexers. Skipping (rather than dereferencing where the runtime allows it) keeps the message identical across TFMs. This runs once per exception type inside the cached factory, not per render.
2. `AppendExceptionProperties` gets a `catch (Exception)` after the existing `TargetInvocationException` clause, rendering `Prop: <unreadable: SomeException(message)>`. Nothing raised while rendering a property — reflection refusing the read, the value's `ToString()` throwing — can replace the real failure any more. Both clauses now use `GetMessageWithoutThrowing()` so a throwing `.Message` inside the catch cannot escape either. Also adds the missing closing `>` to `<getter threw …>`.

One intentional behaviour change on modern .NET: a `ref`-returning property is no longer printed (previously a struct copy was), for identical output across TFMs.

### Tests

Four new tests in `ExceptionHelperOutputExceptionDataTests` (existing tests untouched). Without the fix they are red — `net462`: 3 failures including the issue's exact `NotSupportedException : ByRef return value not supported in reflection invocation.`; `net10.0`: 4 failures. With the fix the fixture and the full `nunit.framework.tests` project pass on `net462`, `net8.0`, `net9.0` and `net10.0`.

Found via sebastienros/jint#3549; Jint made `JavaScriptException.Location` by-value on its side (sebastienros/jint#3564), but any library exposing such a property has the same effect on its consumers' `net462` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNywYGgwa3FvzgJ6WC34By
