### PR TITLE
Fixes of duplicated code after analysis

### DIFF
--- a/src/NUnitFramework/framework/Assert.That.cs
+++ b/src/NUnitFramework/framework/Assert.That.cs
@@ -115,12 +115,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
-            var constraint = expr.Resolve();
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(code);
-            if (!result.IsSuccess)
-                ReportFailure(result, message.ToString(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(code, expr, message, actualExpression, constraintExpression, ReportFailure);
         }
 
         /// <summary>
@@ -135,12 +130,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
-            var constraint = expr.Resolve();
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(code);
-            if (!result.IsSuccess)
-                ReportFailure(result, message.ToString(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(code, expr, message, actualExpression, constraintExpression, ReportFailure);
         }
 
         /// <summary>
@@ -157,12 +147,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
-            var constraint = expr.Resolve();
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(code);
-            if (!result.IsSuccess)
-                ReportFailure(result, getExceptionMessage(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(code, expr, getExceptionMessage, actualExpression, constraintExpression, ReportFailure);
         }
 
         #endregion
@@ -230,12 +215,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
-            var constraint = expression.Resolve();
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(actual);
-            if (!result.IsSuccess)
-                ReportFailure(result, message.ToString(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(actual, expression, message, actualExpression, constraintExpression, ReportFailure);
         }
 
         /// <summary>
@@ -251,12 +231,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
-            var constraint = expression.Resolve();
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(actual);
-            if (!result.IsSuccess)
-                ReportFailure(result, message.ToString(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(actual, expression, message, actualExpression, constraintExpression, ReportFailure);
         }
 
         /// <summary>
@@ -274,12 +249,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
-            var constraint = expression.Resolve();
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(actual);
-            if (!result.IsSuccess)
-                ReportFailure(result, getExceptionMessage(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(actual, expression, getExceptionMessage, actualExpression, constraintExpression, ReportFailure);
         }
 
         #endregion

--- a/src/NUnitFramework/framework/Internal/Commands/TestActionCommand.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestActionCommand.cs
@@ -22,59 +22,21 @@ namespace NUnit.Framework.Internal.Commands
             Guard.ArgumentValid(innerCommand.Test is TestMethod, "TestActionCommand may only apply to a TestMethod", nameof(innerCommand));
             ArgumentNullException.ThrowIfNull(action);
 
-            BeforeTest = context =>
-            {
-                Action beforeTestMethod = context.ExecutionHooksEnabled ?
-                    RunBeforeTestWithHooks : RunBeforeTest;
+            BeforeTest = context => TestActionHookRunner.Run(
+                context,
+                action.GetType(),
+                nameof(ITestAction.BeforeTest),
+                (ctx, m) => ctx.ExecutionHooks.OnBeforeTestActionBeforeTest(ctx, m),
+                (ctx, m, ex) => ctx.ExecutionHooks.OnAfterTestActionBeforeTest(ctx, m, ex),
+                () => action.BeforeTest(Test));
 
-                beforeTestMethod();
-
-                void RunBeforeTestWithHooks()
-                {
-                    var hookedMethodInfo = new MethodWrapper(action.GetType(), nameof(ITestAction.BeforeTest));
-                    try
-                    {
-                        context.ExecutionHooks.OnBeforeTestActionBeforeTest(context, hookedMethodInfo);
-
-                        RunBeforeTest();
-                    }
-                    catch (Exception ex)
-                    {
-                        context.ExecutionHooks.OnAfterTestActionBeforeTest(context, hookedMethodInfo, ex);
-                        throw;
-                    }
-                    context.ExecutionHooks.OnAfterTestActionBeforeTest(context, hookedMethodInfo);
-                }
-
-                void RunBeforeTest() => action.BeforeTest(Test);
-            };
-
-            AfterTest = context =>
-            {
-                Action afterTestMethod = context.ExecutionHooksEnabled ?
-                    RunAfterTestWithHooks : RunAfterTest;
-
-                afterTestMethod();
-
-                void RunAfterTestWithHooks()
-                {
-                    var hookedMethodInfo = new MethodWrapper(action.GetType(), nameof(ITestAction.AfterTest));
-                    try
-                    {
-                        context.ExecutionHooks.OnBeforeTestActionAfterTest(context, hookedMethodInfo);
-
-                        RunAfterTest();
-                    }
-                    catch (Exception ex)
-                    {
-                        context.ExecutionHooks.OnAfterTestActionAfterTest(context, hookedMethodInfo, ex);
-                        throw;
-                    }
-                    context.ExecutionHooks.OnAfterTestActionAfterTest(context, hookedMethodInfo);
-                }
-
-                void RunAfterTest() => action.AfterTest(Test);
-            };
+            AfterTest = context => TestActionHookRunner.Run(
+                context,
+                action.GetType(),
+                nameof(ITestAction.AfterTest),
+                (ctx, m) => ctx.ExecutionHooks.OnBeforeTestActionAfterTest(ctx, m),
+                (ctx, m, ex) => ctx.ExecutionHooks.OnAfterTestActionAfterTest(ctx, m, ex),
+                () => action.AfterTest(Test));
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/Commands/TestActionHookRunner.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestActionHookRunner.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using NUnit.Framework.Interfaces;
+
+namespace NUnit.Framework.Internal.Commands
+{
+    /// <summary>
+    /// Runs a single ITestAction.BeforeTest/AfterTest invocation, wrapping it with the
+    /// matching pair of ExecutionHooks callbacks when hooks are enabled for the context.
+    /// </summary>
+    internal static class TestActionHookRunner
+    {
+        public static void Run(
+            TestExecutionContext context,
+            Type actionType,
+            string methodName,
+            Action<TestExecutionContext, IMethodInfo> onBeforeHook,
+            Action<TestExecutionContext, IMethodInfo, Exception?> onAfterHook,
+            Action run)
+        {
+            if (!context.ExecutionHooksEnabled)
+            {
+                run();
+                return;
+            }
+
+            var hookedMethodInfo = new MethodWrapper(actionType, methodName);
+            try
+            {
+                onBeforeHook(context, hookedMethodInfo);
+                run();
+            }
+            catch (Exception ex)
+            {
+                onAfterHook(context, hookedMethodInfo, ex);
+                throw;
+            }
+
+            onAfterHook(context, hookedMethodInfo, null);
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/Commands/TestActionItem.cs
+++ b/src/NUnitFramework/framework/Internal/Commands/TestActionItem.cs
@@ -1,7 +1,5 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-using System;
-
 namespace NUnit.Framework.Internal.Commands
 {
     /// <summary>
@@ -41,33 +39,17 @@ namespace NUnit.Framework.Internal.Commands
         {
             var context = TestExecutionContext.CurrentContext;
 
-            Action beforeTestMethod = context.ExecutionHooksEnabled ?
-                RunBeforeTestWithHooks : RunBeforeTest;
-
-            beforeTestMethod();
-
-            void RunBeforeTestWithHooks()
-            {
-                var hookedMethodInfo = new MethodWrapper(_action.GetType(), nameof(ITestAction.BeforeTest));
-                try
+            TestActionHookRunner.Run(
+                context,
+                _action.GetType(),
+                nameof(ITestAction.BeforeTest),
+                (ctx, m) => ctx.ExecutionHooks.OnBeforeTestActionBeforeTest(ctx, m),
+                (ctx, m, ex) => ctx.ExecutionHooks.OnAfterTestActionBeforeTest(ctx, m, ex),
+                () =>
                 {
-                    context.ExecutionHooks.OnBeforeTestActionBeforeTest(context, hookedMethodInfo);
-
-                    RunBeforeTest();
-                }
-                catch (Exception ex)
-                {
-                    context.ExecutionHooks.OnAfterTestActionBeforeTest(context, hookedMethodInfo, ex);
-                    throw;
-                }
-                context.ExecutionHooks.OnAfterTestActionBeforeTest(context, hookedMethodInfo);
-            }
-
-            void RunBeforeTest()
-            {
-                BeforeTestWasRun = true;
-                _action.BeforeTest(test);
-            }
+                    BeforeTestWasRun = true;
+                    _action.BeforeTest(test);
+                });
         }
 
         /// <summary>
@@ -78,33 +60,18 @@ namespace NUnit.Framework.Internal.Commands
         public void AfterTest(Interfaces.ITest test)
         {
             var context = TestExecutionContext.CurrentContext;
-            Action afterTestMethod = context.ExecutionHooksEnabled ?
-                RunAfterTestWithHooks : RunAfterTest;
 
-            afterTestMethod();
-
-            void RunAfterTest()
-            {
-                if (BeforeTestWasRun)
-                    _action.AfterTest(test);
-            }
-
-            void RunAfterTestWithHooks()
-            {
-                var hookedMethodInfo = new MethodWrapper(_action.GetType(), nameof(ITestAction.AfterTest));
-                try
+            TestActionHookRunner.Run(
+                context,
+                _action.GetType(),
+                nameof(ITestAction.AfterTest),
+                (ctx, m) => ctx.ExecutionHooks.OnBeforeTestActionAfterTest(ctx, m),
+                (ctx, m, ex) => ctx.ExecutionHooks.OnAfterTestActionAfterTest(ctx, m, ex),
+                () =>
                 {
-                    context.ExecutionHooks.OnBeforeTestActionAfterTest(context, hookedMethodInfo);
-
-                    RunAfterTest();
-                }
-                catch (Exception ex)
-                {
-                    context.ExecutionHooks.OnAfterTestActionAfterTest(context, hookedMethodInfo, ex);
-                    throw;
-                }
-                context.ExecutionHooks.OnAfterTestActionAfterTest(context, hookedMethodInfo);
-            }
+                    if (BeforeTestWasRun)
+                        _action.AfterTest(test);
+                });
         }
     }
 }

--- a/src/NUnitFramework/framework/Internal/ConstraintEvaluator.cs
+++ b/src/NUnitFramework/framework/Internal/ConstraintEvaluator.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using NUnit.Framework.Constraints;
+
+namespace NUnit.Framework.Internal
+{
+    /// <summary>
+    /// Resolves a constraint, applies it, and dispatches the result to a failure handler.
+    /// Shared by <see cref="NUnit.Framework.Assert"/> and <see cref="NUnit.Framework.Warn"/>,
+    /// which differ only in what they do when the constraint is not satisfied.
+    /// </summary>
+    /// <remarks>
+    /// The actual value/delegate and message are passed through as plain generic parameters rather
+    /// than captured in a delegate, so a successful assertion allocates nothing beyond what the
+    /// caller already provided.
+    /// </remarks>
+    internal static class ConstraintEvaluator
+    {
+        public static void Evaluate<TActual, TMessage>(
+            Func<TActual> code,
+            IResolveConstraint expr,
+            TMessage message,
+            string actualExpression,
+            string constraintExpression,
+            Action<ConstraintResult, string, string, string> onFailure)
+        {
+            var constraint = expr.Resolve();
+
+            TestExecutionContext.CurrentContext.IncrementAssertCount();
+            var result = constraint.ApplyTo(code);
+            if (!result.IsSuccess)
+                onFailure(result, message!.ToString()!, actualExpression, constraintExpression);
+        }
+
+        public static void Evaluate<TActual>(
+            Func<TActual> code,
+            IResolveConstraint expr,
+            Func<string> getExceptionMessage,
+            string actualExpression,
+            string constraintExpression,
+            Action<ConstraintResult, string, string, string> onFailure)
+        {
+            var constraint = expr.Resolve();
+
+            TestExecutionContext.CurrentContext.IncrementAssertCount();
+            var result = constraint.ApplyTo(code);
+            if (!result.IsSuccess)
+                onFailure(result, getExceptionMessage(), actualExpression, constraintExpression);
+        }
+
+        public static void Evaluate<TActual, TMessage>(
+            TActual actual,
+            IResolveConstraint expr,
+            TMessage message,
+            string actualExpression,
+            string constraintExpression,
+            Action<ConstraintResult, string, string, string> onFailure)
+        {
+            var constraint = expr.Resolve();
+
+            TestExecutionContext.CurrentContext.IncrementAssertCount();
+            var result = constraint.ApplyTo(actual);
+            if (!result.IsSuccess)
+                onFailure(result, message!.ToString()!, actualExpression, constraintExpression);
+        }
+
+        public static void Evaluate<TActual>(
+            TActual actual,
+            IResolveConstraint expr,
+            Func<string> getExceptionMessage,
+            string actualExpression,
+            string constraintExpression,
+            Action<ConstraintResult, string, string, string> onFailure)
+        {
+            var constraint = expr.Resolve();
+
+            TestExecutionContext.CurrentContext.IncrementAssertCount();
+            var result = constraint.ApplyTo(actual);
+            if (!result.IsSuccess)
+                onFailure(result, getExceptionMessage(), actualExpression, constraintExpression);
+        }
+    }
+}

--- a/src/NUnitFramework/framework/Internal/StackFilter.cs
+++ b/src/NUnitFramework/framework/Internal/StackFilter.cs
@@ -13,7 +13,7 @@ namespace NUnit.Framework.Internal
     /// </summary>
     public class StackFilter
     {
-        private const string DEFAULT_TOP_OF_STACK_PATTERN = @" NUnit\.Framework\.(Assert|Assume|Warn|CollectionAssert|StringAssert|FileAssert|DirectoryAssert)\.";
+        private const string DEFAULT_TOP_OF_STACK_PATTERN = @" NUnit\.Framework\.(Assert|Assume|Warn|CollectionAssert|StringAssert|FileAssert|DirectoryAssert)\.| NUnit\.Framework\.Internal\.ConstraintEvaluator\.";
         private const string DEFAULT_BOTTOM_OF_STACK_PATTERN = @" System\.(Reflection|RuntimeMethodHandle|Threading\.ExecutionContext)\.";
 
         /// <summary>

--- a/src/NUnitFramework/framework/Warn.cs
+++ b/src/NUnitFramework/framework/Warn.cs
@@ -67,7 +67,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
             ConstraintEvaluator.Evaluate(code, expr, message, actualExpression, constraintExpression,
-                (result, msg, ae, ce) => IssueWarning(result, nameof(Unless), msg, ae, ce));
+                IssueUnlessWarning);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
             ConstraintEvaluator.Evaluate(code, expr, message, actualExpression, constraintExpression,
-                (result, msg, ae, ce) => IssueWarning(result, nameof(Unless), msg, ae, ce));
+                IssueUnlessWarning);
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
             ConstraintEvaluator.Evaluate(code, expr, getExceptionMessage, actualExpression, constraintExpression,
-                (result, msg, ae, ce) => IssueWarning(result, nameof(Unless), msg, ae, ce));
+                IssueUnlessWarning);
         }
 
         #endregion
@@ -204,7 +204,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
             ConstraintEvaluator.Evaluate(actual, expression, message, actualExpression, constraintExpression,
-                (result, msg, ae, ce) => IssueWarning(result, nameof(Unless), msg, ae, ce));
+                IssueUnlessWarning);
         }
 
         /// <summary>
@@ -221,7 +221,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
             ConstraintEvaluator.Evaluate(actual, expression, message, actualExpression, constraintExpression,
-                (result, msg, ae, ce) => IssueWarning(result, nameof(Unless), msg, ae, ce));
+                IssueUnlessWarning);
         }
 
         /// <summary>
@@ -240,7 +240,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
             ConstraintEvaluator.Evaluate(actual, expression, getExceptionMessage, actualExpression, constraintExpression,
-                (result, msg, ae, ce) => IssueWarning(result, nameof(Unless), msg, ae, ce));
+                IssueUnlessWarning);
         }
 
         #endregion
@@ -265,7 +265,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
             ConstraintEvaluator.Evaluate(code, new NotConstraint(expr.Resolve()), message, actualExpression, constraintExpression,
-                (result, msg, ae, ce) => IssueWarning(result, nameof(If), msg, ae, ce));
+                IssueIfWarning);
         }
 
         /// <summary>
@@ -282,7 +282,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
             ConstraintEvaluator.Evaluate(code, new NotConstraint(expr.Resolve()), message, actualExpression, constraintExpression,
-                (result, msg, ae, ce) => IssueWarning(result, nameof(If), msg, ae, ce));
+                IssueIfWarning);
         }
 
         /// <summary>
@@ -301,7 +301,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
             ConstraintEvaluator.Evaluate(code, new NotConstraint(expr.Resolve()), getExceptionMessage, actualExpression, constraintExpression,
-                (result, msg, ae, ce) => IssueWarning(result, nameof(If), msg, ae, ce));
+                IssueIfWarning);
         }
 
         #endregion
@@ -402,7 +402,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
             ConstraintEvaluator.Evaluate(actual, new NotConstraint(expression.Resolve()), message, actualExpression, constraintExpression,
-                (result, msg, ae, ce) => IssueWarning(result, nameof(If), msg, ae, ce));
+                IssueIfWarning);
         }
 
         /// <summary>
@@ -419,7 +419,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
             ConstraintEvaluator.Evaluate(actual, new NotConstraint(expression.Resolve()), message, actualExpression, constraintExpression,
-                (result, msg, ae, ce) => IssueWarning(result, nameof(If), msg, ae, ce));
+                IssueIfWarning);
         }
 
         /// <summary>
@@ -438,7 +438,7 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
             ConstraintEvaluator.Evaluate(actual, new NotConstraint(expression.Resolve()), getExceptionMessage, actualExpression, constraintExpression,
-                (result, msg, ae, ce) => IssueWarning(result, nameof(If), msg, ae, ce));
+                IssueIfWarning);
         }
 
         #endregion
@@ -446,6 +446,12 @@ namespace NUnit.Framework
         #endregion
 
         #region Helper Methods
+
+        private static void IssueUnlessWarning(ConstraintResult result, string message, string actualExpression, string constraintExpression)
+            => IssueWarning(result, nameof(Unless), message, actualExpression, constraintExpression);
+
+        private static void IssueIfWarning(ConstraintResult result, string message, string actualExpression, string constraintExpression)
+            => IssueWarning(result, nameof(If), message, actualExpression, constraintExpression);
 
         private static void IssueWarning(ConstraintResult result, string method, string message, string actualExpression, string constraintExpression)
         {

--- a/src/NUnitFramework/framework/Warn.cs
+++ b/src/NUnitFramework/framework/Warn.cs
@@ -66,13 +66,8 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
-            var constraint = expr.Resolve();
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(code);
-
-            if (!result.IsSuccess)
-                IssueWarning(result, nameof(Unless), message.ToString(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(code, expr, message, actualExpression, constraintExpression,
+                (result, msg, ae, ce) => IssueWarning(result, nameof(Unless), msg, ae, ce));
         }
 
         /// <summary>
@@ -88,13 +83,8 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
-            var constraint = expr.Resolve();
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(code);
-
-            if (!result.IsSuccess)
-                IssueWarning(result, nameof(Unless), message.ToString(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(code, expr, message, actualExpression, constraintExpression,
+                (result, msg, ae, ce) => IssueWarning(result, nameof(Unless), msg, ae, ce));
         }
 
         /// <summary>
@@ -112,13 +102,8 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
-            var constraint = expr.Resolve();
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(code);
-
-            if (!result.IsSuccess)
-                IssueWarning(result, nameof(Unless), getExceptionMessage(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(code, expr, getExceptionMessage, actualExpression, constraintExpression,
+                (result, msg, ae, ce) => IssueWarning(result, nameof(Unless), msg, ae, ce));
         }
 
         #endregion
@@ -218,7 +203,8 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
-            Unless(actual, expression, () => message.ToString(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(actual, expression, message, actualExpression, constraintExpression,
+                (result, msg, ae, ce) => IssueWarning(result, nameof(Unless), msg, ae, ce));
         }
 
         /// <summary>
@@ -234,7 +220,8 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
-            Unless(actual, expression, () => message.ToString(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(actual, expression, message, actualExpression, constraintExpression,
+                (result, msg, ae, ce) => IssueWarning(result, nameof(Unless), msg, ae, ce));
         }
 
         /// <summary>
@@ -252,13 +239,8 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
-            var constraint = expression.Resolve();
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(actual);
-
-            if (!result.IsSuccess)
-                IssueWarning(result, nameof(Unless), getExceptionMessage(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(actual, expression, getExceptionMessage, actualExpression, constraintExpression,
+                (result, msg, ae, ce) => IssueWarning(result, nameof(Unless), msg, ae, ce));
         }
 
         #endregion
@@ -282,13 +264,8 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
-            var constraint = new NotConstraint(expr.Resolve());
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(code);
-
-            if (!result.IsSuccess)
-                IssueWarning(result, nameof(If), message.ToString(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(code, new NotConstraint(expr.Resolve()), message, actualExpression, constraintExpression,
+                (result, msg, ae, ce) => IssueWarning(result, nameof(If), msg, ae, ce));
         }
 
         /// <summary>
@@ -304,13 +281,8 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
-            var constraint = new NotConstraint(expr.Resolve());
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(code);
-
-            if (!result.IsSuccess)
-                IssueWarning(result, nameof(If), message.ToString(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(code, new NotConstraint(expr.Resolve()), message, actualExpression, constraintExpression,
+                (result, msg, ae, ce) => IssueWarning(result, nameof(If), msg, ae, ce));
         }
 
         /// <summary>
@@ -328,13 +300,8 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(code))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expr))] string constraintExpression = "")
         {
-            var constraint = new NotConstraint(expr.Resolve());
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(code);
-
-            if (!result.IsSuccess)
-                IssueWarning(result, nameof(If), getExceptionMessage(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(code, new NotConstraint(expr.Resolve()), getExceptionMessage, actualExpression, constraintExpression,
+                (result, msg, ae, ce) => IssueWarning(result, nameof(If), msg, ae, ce));
         }
 
         #endregion
@@ -434,7 +401,8 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
-            If(actual, expression, () => message.ToString(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(actual, new NotConstraint(expression.Resolve()), message, actualExpression, constraintExpression,
+                (result, msg, ae, ce) => IssueWarning(result, nameof(If), msg, ae, ce));
         }
 
         /// <summary>
@@ -450,7 +418,8 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
-            If(actual, expression, () => message.ToString(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(actual, new NotConstraint(expression.Resolve()), message, actualExpression, constraintExpression,
+                (result, msg, ae, ce) => IssueWarning(result, nameof(If), msg, ae, ce));
         }
 
         /// <summary>
@@ -468,13 +437,8 @@ namespace NUnit.Framework
             [CallerArgumentExpression(nameof(actual))] string actualExpression = "",
             [CallerArgumentExpression(nameof(expression))] string constraintExpression = "")
         {
-            var constraint = new NotConstraint(expression.Resolve());
-
-            IncrementAssertCount();
-            var result = constraint.ApplyTo(actual);
-
-            if (!result.IsSuccess)
-                IssueWarning(result, nameof(If), getExceptionMessage(), actualExpression, constraintExpression);
+            ConstraintEvaluator.Evaluate(actual, new NotConstraint(expression.Resolve()), getExceptionMessage, actualExpression, constraintExpression,
+                (result, msg, ae, ce) => IssueWarning(result, nameof(If), msg, ae, ce));
         }
 
         #endregion
@@ -482,11 +446,6 @@ namespace NUnit.Framework
         #endregion
 
         #region Helper Methods
-
-        private static void IncrementAssertCount()
-        {
-            TestExecutionContext.CurrentContext.IncrementAssertCount();
-        }
 
         private static void IssueWarning(ConstraintResult result, string method, string message, string actualExpression, string constraintExpression)
         {


### PR DESCRIPTION
Fixes #5407

I used claude's /code-review first, and the copilot cli (hydrafusion model).  The latter found issues related to extra allocations  and new closures/delegates per assertion, that affected performance.  These were fixed by changing to pass values directly instead.

(Text below written by Claude, a summary of the claude code discussions while working with the code)

## What's done

Two real cases of duplicated logic were found and consolidated (see #5407 for the full analysis, including what was reviewed and deliberately left alone).

### 1. `Assert.That` / `Warn.Unless` / `Warn.If`

All three independently reimplemented the same sequence: resolve the constraint, increment the assert count, apply it, check the result, and hand off to a failure/warning handler. Extracted into a shared internal `Internal/ConstraintEvaluator.cs`, used by all three.

Along the way, each class's own per-message-type overloads (`NUnitString` / `FormattableString` / `Func<string>`) were also collapsed — they had been duplicating that same sequence three times per method. `ConstraintEvaluator` is generic over the actual value/delegate and the message type rather than taking them as delegates, so a successful assertion still allocates nothing beyond what the caller already provided (verified with a before/after allocation check; see #5407 discussion — `Assert.That` is allocation-neutral, `Warn.Unless`/`Warn.If` actually improved by removing a pre-existing closure).

`Internal/StackFilter.cs` needed a matching update: its regex strips NUnit's own frames from a failed assertion/warning's reported stack trace, and only matched `NUnit.Framework.(Assert|Assume|Warn|...)`. Since `ConstraintEvaluator` lives in `NUnit.Framework.Internal`, its frame wasn't matched, which broke stack filtering (caught by `WarningTests.WarningFails`). Extended the pattern to also match `NUnit.Framework.Internal.ConstraintEvaluator`.

### 2. `TestActionCommand` / `TestActionItem`

Both independently duplicated the before/after-test execution-hook wiring — the try/catch around `OnBeforeTestActionBeforeTest`/`OnAfterTestActionBeforeTest` (and the `AfterTest` equivalents). Extracted into a shared internal `Internal/Commands/TestActionHookRunner.cs`.

## Testing

- Full framework test suite passes (`nunit.framework.tests`, net8.0): 6518 passed, 0 failed, unchanged from baseline.
- Builds clean across net462/net8.0/net10.0.