### PR TITLE
Recreate the delayed-constraint wait handle for each fixture execution

### DIFF
--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintFixtureLifecycleTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintFixtureLifecycleTests.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal.Filters;
+using NUnit.Framework.Tests.TestUtilities;
+
+namespace NUnit.Framework.Tests.Constraints
+{
+    [TestFixture, NonParallelizable]
+    public class DelayedConstraintFixtureLifecycleTests
+    {
+        [Test]
+        public void CanRunTheFixtureTwiceWithoutUnloadingItsAssembly()
+        {
+            // Exercise Delay on the test thread so a disposed event is reported as
+            // a test failure rather than escaping from one of the fixture's raw threads.
+            string testName = typeof(DelayedConstraintTests).FullName + "." +
+                nameof(DelayedConstraintTests.ThatBlockingDelegateWhichSucceedsWithoutPolling_ReturnsAfterDelay);
+
+            for (int run = 1; run <= 2; run++)
+            {
+                var work = TestBuilder.CreateWorkItem(typeof(DelayedConstraintTests), new FullNameFilter(testName));
+                ITestResult result = TestBuilder.ExecuteWorkItem(work);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.TotalCount, Is.EqualTo(1), $"Fixture execution {run}");
+                    Assert.That(result.ResultState, Is.EqualTo(ResultState.Success), result.ToXml(true).OuterXml);
+                });
+            }
+        }
+    }
+}

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintFixtureLifecycleTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintFixtureLifecycleTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System.Linq;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Filters;
 using NUnit.Framework.Tests.TestUtilities;
@@ -22,11 +23,9 @@ namespace NUnit.Framework.Tests.Constraints
                 var work = TestBuilder.CreateWorkItem(typeof(DelayedConstraintTests), new FullNameFilter(testName));
                 ITestResult result = TestBuilder.ExecuteWorkItem(work);
 
-                Assert.Multiple(() =>
-                {
-                    Assert.That(result.TotalCount, Is.EqualTo(1), $"Fixture execution {run}");
-                    Assert.That(result.ResultState, Is.EqualTo(ResultState.Success), result.ToXml(true).OuterXml);
-                });
+                Assert.That(result.TotalCount, Is.EqualTo(1), $"Fixture execution {run}");
+                ITestResult childResult = result.Children.First();
+                Assert.That(childResult.ResultState, Is.EqualTo(ResultState.Success), childResult.Message);
             }
         }
     }

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -491,7 +491,7 @@ namespace NUnit.Framework.Tests.Constraints
             return 0;
         }
 
-        private static AutoResetEvent _waitEvent = null!;
+        private static AutoResetEvent _waitEvent;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()

--- a/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
+++ b/src/NUnitFramework/tests/Constraints/DelayedConstraintTests.cs
@@ -491,17 +491,23 @@ namespace NUnit.Framework.Tests.Constraints
             return 0;
         }
 
-        private static readonly AutoResetEvent WaitEvent = new AutoResetEvent(false);
+        private static AutoResetEvent _waitEvent = null!;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            _waitEvent = new AutoResetEvent(false);
+        }
 
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            WaitEvent.Dispose();
+            _waitEvent.Dispose();
         }
 
         private static void Delay(int delay)
         {
-            WaitEvent.WaitOne(delay);
+            _waitEvent.WaitOne(delay);
         }
 
         private static void MethodSetsValues()


### PR DESCRIPTION
Fixes #5415.

`DelayedConstraintTests` initialized its static wait handle once and disposed it in `OneTimeTearDown`. A subsequent fixture execution in the same loaded assembly therefore called `WaitOne` on a disposed handle. Create the event in `OneTimeSetUp` so each execution owns a fresh handle, paired with the existing teardown.

Adds a nonparallelizable regression that uses the existing test helpers to run the fixture through setup, a selected test, and teardown twice. The selected test calls `Delay` on the test thread, so a regression produces an NUnit failure instead of an unhandled exception on a raw worker thread. Existing test assertions and the NUnit framework implementation are unchanged.

Validation:
- The new regression fails on the second execution before the fix (`ObjectDisposedException`) on net462.
- The regression and existing delayed-constraint tests pass on net462, net8.0, net9.0 and net10.0 after the fix.
- `dotnet build nunit.slnx -c Release`: zero warnings or errors.
- `dotnet test nunit.slnx -c Release`: full suite passed on Windows.

The initial full-suite run had one failure in the existing `ConsoleWriteLine_WritesToResult_AdhocContext` test on net9.0 (empty captured stdout). A fresh full-suite run passed without source changes; that test was not modified or suppressed.

Prepared with GPT-6 Astra assistance following our investigation of #5415.
