### PR TITLE
Allow filtered test dependencies to run when dependant can run

### DIFF
--- a/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
+++ b/src/NUnitFramework/framework/Internal/Execution/WorkItemBuilder.cs
@@ -57,12 +57,17 @@ namespace NUnit.Framework.Internal.Execution
                 var manager = TestDependencyManager.Create(suite);
                 var testDependencies = manager?.PrepareTestDependencies(suite);
                 var children = testDependencies is null ? suite.Tests : TopologicalSort(suite.Tests, testDependencies);
+                HashSet<ITest>? dependencyClosure = testDependencies is null ? null : GetDependencyClosure(suite.Tests, testDependencies, filter);
 
                 int countOrderedItems = 0;
 
                 foreach (var childTest in children)
                 {
-                    var childItem = CreateWorkItem(childTest, filter, debugger, recursive, root: false);
+                    // Always include tests that are dependencies of other tests, even if they don't match the filter
+                    var forceIncludeTest = dependencyClosure?.Contains(childTest) == true;
+                    var childFilter = forceIncludeTest ? TestFilter.Empty : filter;
+
+                    var childItem = CreateWorkItem(childTest, childFilter, debugger, recursive, root: forceIncludeTest);
                     if (childItem is null)
                         continue;
 
@@ -87,6 +92,28 @@ namespace NUnit.Framework.Internal.Execution
             }
 
             return work;
+        }
+
+        private static HashSet<ITest> GetDependencyClosure(IList<ITest> tests, Dictionary<ITest, ITest> dependencyGraph, ITestFilter filter)
+        {
+            var includedTests = new HashSet<ITest>();
+
+            foreach (var test in tests)
+            {
+                if (filter.Pass(test))
+                    IncludeDependencies(test);
+            }
+
+            return includedTests;
+
+            void IncludeDependencies(ITest test)
+            {
+                if (!includedTests.Add(test))
+                    return;
+
+                if (dependencyGraph.TryGetValue(test, out ITest? dependency))
+                    IncludeDependencies(dependency);
+            }
         }
 
         private static List<ITest> TopologicalSort(IList<ITest> tests, Dictionary<ITest, ITest> dependencyGraph)

--- a/src/NUnitFramework/testdata/DependsOnFixtureAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/DependsOnFixtureAttributeFixture.cs
@@ -128,6 +128,40 @@ namespace NUnit.TestData
             Assert.That(true, Is.True);
         }
     }
+
+    [TestFixture]
+    public class FixtureDependencyFilteredOutDependentBefore
+    {
+        [Test]
+        public void BeforeTest()
+        {
+            FixtureDependencyEvents.Record();
+            Assert.That(true, Is.True);
+        }
+    }
+
+    [TestFixture]
+    [DependsOnFixture(typeof(FixtureDependencyFilteredOutDependentBefore))]
+    public class FixtureDependencyFilteredOutDependentAfter
+    {
+        [Test]
+        public void AfterTest()
+        {
+            FixtureDependencyEvents.Record();
+            Assert.That(true, Is.True);
+        }
+    }
+
+    [TestFixture]
+    public class FixtureDependencyFilteredOutIndependent
+    {
+        [Test]
+        public void IndependentTest()
+        {
+            FixtureDependencyEvents.Record();
+            Assert.That(true, Is.True);
+        }
+    }
     #endregion
 
     #region Referential Integrity

--- a/src/NUnitFramework/testdata/DependsOnTestAttributeFixture.cs
+++ b/src/NUnitFramework/testdata/DependsOnTestAttributeFixture.cs
@@ -220,6 +220,35 @@ namespace NUnit.TestData
     }
 
     [TestFixture]
+    public class MethodDependencyFilteredOutDependent
+    {
+        [Test]
+        public void Before()
+        {
+            FixtureDependencyEvents.Record();
+            Assert.That(true, Is.True);
+        }
+
+        [Test]
+        [DependsOnTest(nameof(Before))]
+        public void After()
+        {
+            FixtureDependencyEvents.Record();
+            Assert.That(true, Is.True);
+        }
+
+        [Test]
+#pragma warning disable CS0618 // Type or member is obsolete
+        [Order(1)]
+#pragma warning restore CS0618 // Type or member is obsolete
+        public void OrderedIndependent()
+        {
+            FixtureDependencyEvents.Record();
+            Assert.That(true, Is.True);
+        }
+    }
+
+    [TestFixture]
     public class MethodDependencyParallel
     {
         [Test]

--- a/src/NUnitFramework/tests/Attributes/DependsOnFixtureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnFixtureAttributeTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Execution;
+using NUnit.Framework.Internal.Filters;
 using NUnit.Framework.Tests.TestUtilities;
 using NUnit.TestData;
 
@@ -122,6 +123,30 @@ namespace NUnit.Framework.Tests.Attributes
             {
                 Assert.That(beforeResult.ResultState.Status, Is.EqualTo(TestStatus.Failed));
                 Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+            }
+        }
+
+        [Test]
+        public void FilteredOutDependencyFixtureIsStillRunWhenDependentFixtureIsSelected()
+        {
+            var suite = new TestSuite("dummy").Containing(typeof(FixtureDependsOnFixtureWithInternalMethodDependencies), typeof(MethodDependencyOrdered));
+            var filter = new FullNameFilter(typeof(FixtureDependsOnFixtureWithInternalMethodDependencies).FullName!);
+
+            var work = TestBuilder.CreateWorkItem(suite, filter);
+            var result = TestBuilder.ExecuteWorkItem(work);
+
+            var dependencyResult = result.Children.Single(x => x.Name == nameof(MethodDependencyOrdered));
+            var dependencyChildren = dependencyResult.Children.ToArray();
+            var dependentResult = result.Children.Single(x => x.Name == nameof(FixtureDependsOnFixtureWithInternalMethodDependencies));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(dependencyResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(dependentResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(dependencyChildren, Has.Length.EqualTo(2));
+                Assert.That(dependencyChildren[0].Name, Is.EqualTo(nameof(MethodDependencyOrdered.Before)));
+                Assert.That(dependencyChildren[1].Name, Is.EqualTo(nameof(MethodDependencyOrdered.After)));
+                Assert.That(FixtureDependencyEvents.Events, Is.EqualTo([nameof(MethodDependencyOrdered.Before), nameof(MethodDependencyOrdered.After), nameof(FixtureDependsOnFixtureWithInternalMethodDependencies.AfterTest)]));
             }
         }
 

--- a/src/NUnitFramework/tests/Attributes/DependsOnFixtureAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnFixtureAttributeTests.cs
@@ -151,6 +151,26 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         [Test]
+        public void FilteredOutDependencyIsNotRunWhenDependentFixtureIsFilteredOut()
+        {
+            var suite = new TestSuite("dummy").Containing(typeof(FixtureDependencyFilteredOutDependentAfter), typeof(FixtureDependencyFilteredOutDependentBefore), typeof(FixtureDependencyFilteredOutIndependent));
+            var filter = new FullNameFilter(typeof(FixtureDependencyFilteredOutIndependent).FullName!);
+
+            var work = TestBuilder.CreateWorkItem(suite, filter);
+            var result = TestBuilder.ExecuteWorkItem(work);
+
+            var resultChildren = result.Children.ToArray();
+            var independentResult = resultChildren.Single(x => x.Name == nameof(FixtureDependencyFilteredOutIndependent));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(resultChildren, Has.Length.EqualTo(1));
+                Assert.That(independentResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(FixtureDependencyEvents.Events, Is.EqualTo([nameof(FixtureDependencyFilteredOutIndependent.IndependentTest)]));
+            }
+        }
+
+        [Test]
         public void DependentTestsAreOrderedWhenDependenciesFork()
         {
             var suite = new TestSuite("dummy").Containing(typeof(ForkingDependencyRoot), typeof(ForkingDependencyNodeA), typeof(ForkingDependencyNodeB));

--- a/src/NUnitFramework/tests/Attributes/DependsOnTestAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnTestAttributeTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Execution;
+using NUnit.Framework.Internal.Filters;
 using NUnit.Framework.Tests.TestUtilities;
 using NUnit.TestData;
 
@@ -115,6 +116,24 @@ namespace NUnit.Framework.Tests.Attributes
                 Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
                 Assert.That(FixtureDependencyEvents.Events, Does.Contain(nameof(MethodDependencyFailingAllowed.BeforeFailing)));
                 Assert.That(FixtureDependencyEvents.Events, Does.Contain(nameof(MethodDependencyFailingAllowed.AfterFailingAllowed)));
+            }
+        }
+
+        [Test]
+        public void FilteredOutDependencyIsStillRunWhenDependentTestIsSelected()
+        {
+            var filter = new MethodNameFilter(nameof(MethodDependencyOrdered.After));
+            var work = TestBuilder.CreateWorkItem(typeof(MethodDependencyOrdered), filter);
+            var result = TestBuilder.ExecuteWorkItem(work);
+
+            var beforeResult = result.Children.Single(x => x.Name == nameof(MethodDependencyOrdered.Before));
+            var afterResult = result.Children.Single(x => x.Name == nameof(MethodDependencyOrdered.After));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(beforeResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(afterResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(FixtureDependencyEvents.Events, Is.EqualTo([nameof(MethodDependencyOrdered.Before), nameof(MethodDependencyOrdered.After)]));
             }
         }
 

--- a/src/NUnitFramework/tests/Attributes/DependsOnTestAttributeTests.cs
+++ b/src/NUnitFramework/tests/Attributes/DependsOnTestAttributeTests.cs
@@ -138,6 +138,24 @@ namespace NUnit.Framework.Tests.Attributes
         }
 
         [Test]
+        public void FilteredOutDependencyIsNotRunWhenDependentTestIsFilteredOut()
+        {
+            var filter = new MethodNameFilter(nameof(MethodDependencyFilteredOutDependent.OrderedIndependent));
+            var work = TestBuilder.CreateWorkItem(typeof(MethodDependencyFilteredOutDependent), filter);
+            var result = TestBuilder.ExecuteWorkItem(work);
+
+            var resultChildren = result.Children.ToArray();
+            var orderedResult = resultChildren.Single(x => x.Name == nameof(MethodDependencyFilteredOutDependent.OrderedIndependent));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(resultChildren, Has.Length.EqualTo(1));
+                Assert.That(orderedResult.ResultState.Status, Is.EqualTo(TestStatus.Passed));
+                Assert.That(FixtureDependencyEvents.Events, Is.EqualTo([nameof(MethodDependencyFilteredOutDependent.OrderedIndependent)]));
+            }
+        }
+
+        [Test]
         public void DependentTestIsNotRunnableIfDependencyAbsent()
         {
             var work = TestBuilder.CreateWorkItem(typeof(MethodDependencyMissing));


### PR DESCRIPTION
Fixes #5396